### PR TITLE
Remove unused configuration field from connector creation UI

### DIFF
--- a/frontend/src/components/ConnectorModal.tsx
+++ b/frontend/src/components/ConnectorModal.tsx
@@ -16,7 +16,6 @@ const connectorSchema = z.object({
   }),
   name: z.string().min(1, 'Name is required').max(100, 'Name must be less than 100 characters'),
   description: z.string().optional(),
-  configuration: z.string().optional(),
 })
 
 type ConnectorFormData = z.infer<typeof connectorSchema>
@@ -160,7 +159,12 @@ export default function ConnectorModal({
   }
 
   const onSubmit = (data: ConnectorFormData) => {
-    createMutation.mutate(data)
+    // Add configuration as null since it's not used yet
+    const payload = {
+      ...data,
+      configuration: null
+    }
+    createMutation.mutate(payload as any)
   }
 
   console.log('ConnectorModal render:', { isOpen, step, selectedType })
@@ -272,25 +276,6 @@ export default function ConnectorModal({
                   />
                   {errors.description && (
                     <p className="mt-1 text-sm text-error-600">{errors.description.message}</p>
-                  )}
-                </div>
-
-                {/* Configuration */}
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Configuration (JSON)
-                  </label>
-                  <textarea
-                    {...register('configuration')}
-                    className="input-field font-mono text-sm"
-                    rows={6}
-                    placeholder='{"api_key": "your-key", "base_url": "https://api.example.com"}'
-                  />
-                  <p className="mt-1 text-xs text-gray-500">
-                    Optional JSON configuration for the connector
-                  </p>
-                  {errors.configuration && (
-                    <p className="mt-1 text-sm text-error-600">{errors.configuration.message}</p>
                   )}
                 </div>
 


### PR DESCRIPTION
- Remove configuration field from ConnectorModal form schema
- Remove configuration textarea from UI
- Send configuration as null to backend since it's not currently used
- Fixes validation error when creating connectors

The configuration field was defined in the database schema but is not used by any connector implementation. Removed from UI to simplify the connector creation flow. Can be added back when needed for custom connector types.

Before

<img width="836" height="261" alt="Screenshot 2025-10-10 at 6 43 31 PM" src="https://github.com/user-attachments/assets/db45dbac-c8bf-46a1-bee5-9f5eb7f6f8b4" />

After

Able to create connector

<img width="1669" height="628" alt="Screenshot 2025-10-10 at 11 02 48 AM" src="https://github.com/user-attachments/assets/0cccbe60-49d4-44b0-8708-672d4f411f6e" />

