### PR TITLE
Implement connector-specific MCP URLs

### DIFF
--- a/frontend/src/components/ConnectorModal.tsx
+++ b/frontend/src/components/ConnectorModal.tsx
@@ -24,10 +24,12 @@ type ConnectorFormData = z.infer<typeof connectorSchema>
 const ConnectorTypeCard = ({
   type,
   selected,
+  disabled,
   onSelect,
 }: {
   type: ConnectorType
   selected: boolean
+  disabled?: boolean
   onSelect: (type: ConnectorType) => void
 }) => {
   const configs = {
@@ -69,10 +71,13 @@ const ConnectorTypeCard = ({
   return (
     <button
       type="button"
-      onClick={() => onSelect(type)}
+      onClick={() => !disabled && onSelect(type)}
+      disabled={disabled}
       className={cn(
-        'p-4 border-2 rounded-lg transition-all text-left w-full',
-        selected
+        'p-4 border-2 rounded-lg transition-all text-left w-full relative',
+        disabled
+          ? 'border-gray-200 bg-gray-50 opacity-60 cursor-not-allowed'
+          : selected
           ? 'border-primary-500 bg-primary-50'
           : 'border-gray-200 hover:border-gray-300'
       )}
@@ -83,7 +88,9 @@ const ConnectorTypeCard = ({
         </div>
         <div className="flex-1 min-w-0">
           <h4 className="text-sm font-medium text-gray-900">{config.name}</h4>
-          <p className="text-xs text-gray-500 mt-1">{config.description}</p>
+          <p className="text-xs text-gray-500 mt-1">
+            {disabled ? 'Already exists for this tenant' : config.description}
+          </p>
         </div>
       </div>
     </button>
@@ -122,6 +129,17 @@ export default function ConnectorModal({
     queryFn: () => tenantsApi.list().then(res => res.data),
     enabled: isOpen
   })
+
+  // Fetch existing connectors for the selected tenant to check for duplicates
+  const selectedTenantSlug = preselectedTenant || undefined
+  const { data: existingConnectors = [] } = useQuery({
+    queryKey: ['connectors', selectedTenantSlug],
+    queryFn: () => selectedTenantSlug ? connectorsApi.list(selectedTenantSlug).then(res => res.data) : Promise.resolve([]),
+    enabled: isOpen && !!selectedTenantSlug
+  })
+
+  // Get list of connector types already in use
+  const usedConnectorTypes = new Set(existingConnectors.map(c => c.connector_type))
 
   const createMutation = useMutation({
     mutationFn: ({ tenant_slug, ...data }: ConnectorFormData) => 
@@ -199,6 +217,7 @@ export default function ConnectorModal({
                     key={type}
                     type={type}
                     selected={selectedType === type}
+                    disabled={usedConnectorTypes.has(type)}
                     onSelect={handleTypeSelect}
                   />
                 ))}

--- a/frontend/src/pages/TenantDetail.tsx
+++ b/frontend/src/pages/TenantDetail.tsx
@@ -16,7 +16,7 @@ import {
   Copy
 } from 'lucide-react'
 import toast from 'react-hot-toast'
-import { tenantsApi, connectorsApi, mcpApi } from '@/utils/api'
+import { tenantsApi, connectorsApi } from '@/utils/api'
 import { cn } from '@/utils/cn'
 import ConnectorModal from '@/components/ConnectorModal'
 import OAuthManager from '@/components/OAuthManager'
@@ -47,8 +47,9 @@ const ConnectorCard = ({ connector, tenantSlug }: { connector: any, tenantSlug: 
   const [showMenu, setShowMenu] = useState(false)
   const queryClient = useQueryClient()
 
-  const mcpWebSocketUrl = `ws://${window.location.host}/${tenantSlug}/mcp`
-  const mcpHttpUrl = `http://${window.location.host}/api/v1/${tenantSlug}/mcp`
+  // Connector-specific URLs
+  const mcpWebSocketUrl = `ws://${window.location.host}/${tenantSlug}/connectors/${connector.id}/mcp`
+  const mcpHttpUrl = `http://${window.location.host}/api/v1/${tenantSlug}/connectors/${connector.id}/mcp`
   const isLocalhost = window.location.hostname === 'localhost'
 
   const copyUrl = (url: string, type: string) => {
@@ -219,12 +220,6 @@ export default function TenantDetail() {
     enabled: !!slug
   })
 
-  const { data: mcpInfo } = useQuery({
-    queryKey: ['mcp-info', slug],
-    queryFn: () => mcpApi.getInfo(slug!).then(res => res.data),
-    enabled: !!slug
-  })
-
   if (tenantLoading) {
     return (
       <div className="space-y-6">
@@ -368,52 +363,15 @@ export default function TenantDetail() {
             <div className="card-content">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-600">MCP Status</p>
+                  <p className="text-sm font-medium text-gray-600">Connector Types</p>
                   <p className="text-2xl font-bold text-gray-900">
-                    {mcpInfo ? 'Ready' : 'Loading...'}
+                    {new Set(connectors.map(c => c.connector_type)).size}
                   </p>
                 </div>
                 <Building2 className="h-8 w-8 text-primary-600" />
               </div>
             </div>
           </div>
-
-          {/* MCP Info */}
-          {mcpInfo && (
-            <div className="md:col-span-3">
-              <div className="card">
-                <div className="card-header">
-                  <h3 className="text-lg font-semibold text-gray-900">MCP Server Information</h3>
-                </div>
-                <div className="card-content">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                      <p className="text-sm font-medium text-gray-600">Server Name</p>
-                      <p className="text-gray-900">{mcpInfo.server_name}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm font-medium text-gray-600">Server Version</p>
-                      <p className="text-gray-900">{mcpInfo.server_version}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm font-medium text-gray-600">Protocol Version</p>
-                      <p className="text-gray-900">{mcpInfo.protocol_version}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm font-medium text-gray-600">Capabilities</p>
-                      <div className="flex flex-wrap gap-1 mt-1">
-                        {Object.keys(mcpInfo.capabilities).map(cap => (
-                          <span key={cap} className="status-badge bg-primary-100 text-primary-800">
-                            {cap}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
 
           {/* Contact Info */}
           {tenant.contact_email && (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,6 +45,9 @@ export enum ConnectorType {
 
 export interface MCPServerInfo {
   tenant: string
+  connector_id: string
+  connector_name: string
+  connector_type: string
   server_name: string
   server_version: string
   protocol_version: string
@@ -53,11 +56,6 @@ export interface MCPServerInfo {
     resources?: { subscribe?: boolean; listChanged?: boolean }
     prompts?: { listChanged?: boolean }
   }
-  connectors: Array<{
-    type: string
-    name: string
-    enabled: boolean
-  }>
 }
 
 export interface APIResponse<T> {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -102,10 +102,10 @@ export const connectorsApi = {
 }
 
 export const mcpApi = {
-  getInfo: (tenantSlug: string) => 
-    api.get<MCPServerInfo>(`/${tenantSlug}/mcp/info`),
-  sendMessage: (tenantSlug: string, message: any) => 
-    api.post(`/${tenantSlug}/mcp`, message),
+  getInfo: (tenantSlug: string, connectorId: string) =>
+    api.get<MCPServerInfo>(`/${tenantSlug}/connectors/${connectorId}/mcp/info`),
+  sendMessage: (tenantSlug: string, connectorId: string, message: any) =>
+    api.post(`/${tenantSlug}/connectors/${connectorId}/mcp`, message),
 }
 
 export const oauthApi = {

--- a/src/sage_mcp/mcp/transport.py
+++ b/src/sage_mcp/mcp/transport.py
@@ -12,9 +12,10 @@ from .server import MCPServer
 class MCPTransport:
     """Transport layer for MCP communication."""
 
-    def __init__(self, tenant_slug: str):
+    def __init__(self, tenant_slug: str, connector_id: str = None):
         self.tenant_slug = tenant_slug
-        self.mcp_server = MCPServer(tenant_slug)
+        self.connector_id = connector_id
+        self.mcp_server = MCPServer(tenant_slug, connector_id)
         self.initialized = False
 
     async def initialize(self) -> bool:

--- a/src/sage_mcp/models/connector.py
+++ b/src/sage_mcp/models/connector.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from sqlalchemy import Boolean, Enum, ForeignKey, String, Text, TypeDecorator
+from sqlalchemy import Boolean, Enum, ForeignKey, String, Text, TypeDecorator, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -54,6 +54,9 @@ class Connector(Base):
     """Connector configuration for tenants."""
 
     __tablename__ = "connectors"
+    __table_args__ = (
+        UniqueConstraint('tenant_id', 'connector_type', name='uq_tenant_connector_type'),
+    )
 
     # Foreign key to tenant
     tenant_id: Mapped[uuid.UUID] = mapped_column(


### PR DESCRIPTION
Backend changes:
- Updated MCP routes to accept connector_id parameter
- Modified MCPServer to load single connector by ID
- Updated MCPTransport to handle connector-specific initialization
- Added unique constraint on (tenant_id, connector_type) in Connector model
- Enhanced duplicate checking in connector creation endpoint

Frontend changes:
- Added connector selection dropdown in MCP Testing page
- Updated MCPServerInfo type with connector_id, connector_name, connector_type
- Modified API calls to use connector-specific URLs
- Enhanced TenantDetail to display connector-specific MCP URLs
- Added duplicate prevention in ConnectorModal

URL pattern changed from:
  /{tenant_slug}/mcp to:
  /{tenant_slug}/connectors/{connector_id}/mcp

