### PR TITLE
Fix SQLAlchemy query bug in OAuth credential lookup

### DIFF
--- a/src/sage_mcp/mcp/server.py
+++ b/src/sage_mcp/mcp/server.py
@@ -285,7 +285,7 @@ class MCPServer:
                 select(OAuthCredential).where(
                     OAuthCredential.tenant_id == tenant_id,
                     OAuthCredential.provider == provider,
-                    OAuthCredential.is_active is True
+                    OAuthCredential.is_active.is_(True)
                 )
             )
             return result.scalar_one_or_none()


### PR DESCRIPTION
Changed `is True` to `is(True)` in the OAuth credential query WHERE clause. Using Python's `is` operator in SQLAlchemy queries causes the ORM to generate `WHERE false`, which returns no results.

This bug prevented OAuth credentials from being retrieved, causing all GitHub API calls to fail with "Invalid or expired GitHub credentials" even when valid credentials existed in the database.

The fix ensures the query generates correct SQL:
`WHERE is_active = true` instead of `WHERE false`