### PR TITLE
Add Connection Info modal to connector cards

### DIFF
--- a/frontend/src/pages/TenantDetail.tsx
+++ b/frontend/src/pages/TenantDetail.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { 
-  ArrowLeft, 
-  Building2, 
-  Plug, 
-  Activity, 
+import {
+  ArrowLeft,
+  Building2,
+  Plug,
+  Activity,
   Settings,
   Plus,
   MoreVertical,
@@ -13,7 +13,9 @@ import {
   Trash2,
   ToggleLeft,
   ToggleRight,
-  Copy
+  Copy,
+  Info,
+  X
 } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { tenantsApi, connectorsApi } from '@/utils/api'
@@ -43,19 +45,183 @@ const TabButton = ({
   </button>
 )
 
-const ConnectorCard = ({ connector, tenantSlug }: { connector: any, tenantSlug: string }) => {
-  const [showMenu, setShowMenu] = useState(false)
-  const queryClient = useQueryClient()
-
-  // Connector-specific URLs
+const ConnectionInfoModal = ({
+  isOpen,
+  onClose,
+  connector,
+  tenantSlug
+}: {
+  isOpen: boolean
+  onClose: () => void
+  connector: any
+  tenantSlug: string
+}) => {
   const mcpWebSocketUrl = `ws://${window.location.host}/${tenantSlug}/connectors/${connector.id}/mcp`
   const mcpHttpUrl = `http://${window.location.host}/api/v1/${tenantSlug}/connectors/${connector.id}/mcp`
   const isLocalhost = window.location.hostname === 'localhost'
 
   const copyUrl = (url: string, type: string) => {
     navigator.clipboard.writeText(url)
-    toast.success(`MCP ${type} URL copied to clipboard`)
+    toast.success(`${type} URL copied to clipboard`)
   }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <div className="fixed inset-0 bg-gray-500 bg-opacity-75" onClick={onClose} />
+        <div className="relative bg-white rounded-lg shadow-xl max-w-2xl w-full">
+          {/* Header */}
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900">Connection Information</h3>
+              <p className="text-sm text-gray-600">{connector.name}</p>
+            </div>
+            <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+              <X className="h-6 w-6" />
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="px-6 py-4 space-y-4">
+            {/* WebSocket URL */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                WebSocket URL
+              </label>
+              <div className="flex items-center space-x-2">
+                <input
+                  type="text"
+                  value={mcpWebSocketUrl}
+                  readOnly
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 font-mono text-sm"
+                />
+                <button
+                  onClick={() => copyUrl(mcpWebSocketUrl, 'WebSocket')}
+                  className="btn-secondary"
+                >
+                  <Copy className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* HTTP URL */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                HTTP URL
+              </label>
+              <div className="flex items-center space-x-2">
+                <input
+                  type="text"
+                  value={mcpHttpUrl}
+                  readOnly
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 font-mono text-sm"
+                />
+                <button
+                  onClick={() => copyUrl(mcpHttpUrl, 'HTTP')}
+                  className="btn-secondary"
+                >
+                  <Copy className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* Claude Desktop Setup Instructions */}
+            <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+              <h4 className="text-sm font-semibold text-blue-900 mb-2">
+                Claude Desktop Setup
+              </h4>
+              {isLocalhost ? (
+                <div className="text-sm text-blue-800 space-y-2">
+                  <p><strong>Note:</strong> You're running on localhost. For Claude Desktop to connect, you need to expose your server via HTTPS:</p>
+                  <ol className="list-decimal list-inside space-y-1 ml-2">
+                    <li>Install ngrok: <code className="bg-blue-100 px-1 rounded">brew install ngrok</code></li>
+                    <li>Run: <code className="bg-blue-100 px-1 rounded">ngrok http 3000</code></li>
+                    <li>Copy the HTTPS URL from ngrok (e.g., <code className="bg-blue-100 px-1 rounded">https://abc123.ngrok.io</code>)</li>
+                    <li>Install mcp-remote if needed: <code className="bg-blue-100 px-1 rounded">npm install -g mcp-remote</code></li>
+                    <li>Add to Claude Desktop config:</li>
+                  </ol>
+                  <pre className="bg-blue-100 p-3 rounded mt-2 overflow-x-auto text-xs">
+{`{
+  "mcpServers": {
+    "${connector.name}": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://your-ngrok-url.ngrok.io/api/v1/${tenantSlug}/connectors/${connector.id}/mcp"
+      ]
+    }
+  }
+}`}
+                  </pre>
+                  <p className="mt-2 text-xs text-blue-700">
+                    <strong>Note:</strong> If npx is not found, add an <code className="bg-blue-100 px-1 rounded">"env"</code> section with your Node.js PATH. Find it with: <code className="bg-blue-100 px-1 rounded">echo $PATH</code>
+                  </p>
+                  <pre className="bg-blue-100 p-2 rounded text-xs mt-1">
+{`"env": {
+  "PATH": "/path/to/node/bin:/usr/local/bin:/usr/bin:/bin"
+}`}
+                  </pre>
+                </div>
+              ) : (
+                <div className="text-sm text-blue-800 space-y-2">
+                  <p>Add this configuration to your Claude Desktop config file:</p>
+                  <ol className="list-decimal list-inside space-y-1 ml-2 mb-2">
+                    <li>Install mcp-remote if needed: <code className="bg-blue-100 px-1 rounded">npm install -g mcp-remote</code></li>
+                    <li>Add the configuration below:</li>
+                  </ol>
+                  <pre className="bg-blue-100 p-3 rounded mt-2 overflow-x-auto text-xs">
+{`{
+  "mcpServers": {
+    "${connector.name}": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "${mcpHttpUrl}"
+      ]
+    }
+  }
+}`}
+                  </pre>
+                  <p className="mt-2 text-xs text-blue-700">
+                    <strong>Note:</strong> If npx is not found, add an <code className="bg-blue-100 px-1 rounded">"env"</code> section with your Node.js PATH. Find it with: <code className="bg-blue-100 px-1 rounded">echo $PATH</code>
+                  </p>
+                  <pre className="bg-blue-100 p-2 rounded text-xs mt-1">
+{`"env": {
+  "PATH": "/path/to/node/bin:/usr/local/bin:/usr/bin:/bin"
+}`}
+                  </pre>
+                  <p className="mt-2 text-xs">
+                    Config file location:
+                    <br />
+                    • macOS: <code className="bg-blue-100 px-1 rounded">~/Library/Application Support/Claude/claude_desktop_config.json</code>
+                    <br />
+                    • Windows: <code className="bg-blue-100 px-1 rounded">%APPDATA%\Claude\claude_desktop_config.json</code>
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="px-6 py-4 border-t border-gray-200 flex justify-end">
+            <button onClick={onClose} className="btn-primary">
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const ConnectorCard = ({ connector, tenantSlug }: { connector: any, tenantSlug: string }) => {
+  const [showMenu, setShowMenu] = useState(false)
+  const [showConnectionInfo, setShowConnectionInfo] = useState(false)
+  const queryClient = useQueryClient()
 
 
   const deleteMutation = useMutation({
@@ -88,118 +254,86 @@ const ConnectorCard = ({ connector, tenantSlug }: { connector: any, tenantSlug: 
   }
 
   return (
-    <div className="card">
-      <div className="card-content">
-        <div className="flex items-start justify-between">
-          <div>
-            <h4 className="font-medium text-gray-900">{connector.name}</h4>
-            <p className="text-sm text-gray-600 capitalize">{connector.connector_type}</p>
-            {connector.description && (
-              <p className="text-sm text-gray-500 mt-1">{connector.description}</p>
-            )}
-            
-            {/* MCP Server URLs */}
-            <div className="mt-2 p-2 bg-gray-50 rounded border">
-              <p className="text-xs font-medium text-gray-700 mb-2">MCP Server URLs:</p>
-              
-              {/* WebSocket URL */}
-              <div className="mb-2">
-                <div className="flex items-center justify-between">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-xs text-gray-600 mb-1">WebSocket:</p>
-                    <p className="text-xs font-mono text-gray-600 truncate">{mcpWebSocketUrl}</p>
-                  </div>
-                  <button
-                    onClick={() => copyUrl(mcpWebSocketUrl, 'WebSocket')}
-                    className="ml-2 p-1 hover:bg-gray-200 rounded"
-                    title="Copy WebSocket URL"
-                  >
-                    <Copy className="h-3 w-3 text-gray-500" />
-                  </button>
-                </div>
-              </div>
+    <>
+      <ConnectionInfoModal
+        isOpen={showConnectionInfo}
+        onClose={() => setShowConnectionInfo(false)}
+        connector={connector}
+        tenantSlug={tenantSlug}
+      />
 
-              {/* HTTP URL */}
-              <div className="mb-2">
-                <div className="flex items-center justify-between">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-xs text-gray-600 mb-1">HTTP:</p>
-                    <p className="text-xs font-mono text-gray-600 truncate">{mcpHttpUrl}</p>
-                  </div>
-                  <button
-                    onClick={() => copyUrl(mcpHttpUrl, 'HTTP')}
-                    className="ml-2 p-1 hover:bg-gray-200 rounded"
-                    title="Copy HTTP URL"
-                  >
-                    <Copy className="h-3 w-3 text-gray-500" />
-                  </button>
-                </div>
-              </div>
+      <div className="card">
+        <div className="card-content">
+          <div className="flex items-start justify-between">
+            <div className="flex-1">
+              <h4 className="font-medium text-gray-900">{connector.name}</h4>
+              <p className="text-sm text-gray-600 capitalize">{connector.connector_type}</p>
+              {connector.description && (
+                <p className="text-sm text-gray-500 mt-1">{connector.description}</p>
+              )}
 
-              {isLocalhost && (
-                <div className="mt-2 p-2 bg-blue-50 border border-blue-200 rounded">
-                  <p className="text-xs text-blue-700">
-                    <strong>For Claude:</strong> Use the HTTP URL with ngrok for HTTPS:
-                    <br />
-                    1. Run: <code className="bg-blue-100 px-1 rounded">ngrok http 3000</code>
-                    <br />
-                    2. Use: <code className="bg-blue-100 px-1 rounded">https://your-ngrok-url.ngrok.io/api/v1/{tenantSlug}/mcp</code>
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-          <div className="flex items-center space-x-2">
-            <span className={cn(
-              'status-badge',
-              connector.is_enabled ? 'status-active' : 'status-inactive'
-            )}>
-              {connector.is_enabled ? 'Enabled' : 'Disabled'}
-            </span>
-            
-            <button 
-              onClick={() => toggleMutation.mutate()}
-              disabled={toggleMutation.isPending}
-              className="p-1 hover:bg-gray-100 rounded disabled:opacity-50"
-            >
-              {connector.is_enabled ? (
-                <ToggleRight className="h-5 w-5 text-success-600" />
-              ) : (
-                <ToggleLeft className="h-5 w-5 text-gray-400" />
-              )}
-            </button>
-            
-            <div className="relative">
+              {/* Connection Info Button */}
               <button
-                onClick={() => setShowMenu(!showMenu)}
-                className="p-1 hover:bg-gray-100 rounded"
+                onClick={() => setShowConnectionInfo(true)}
+                className="mt-3 inline-flex items-center text-sm text-primary-600 hover:text-primary-700 font-medium"
               >
-                <MoreVertical className="h-4 w-4 text-gray-400" />
+                <Info className="h-4 w-4 mr-1" />
+                Connection Info
               </button>
-              
-              {showMenu && (
-                <div className="absolute right-0 mt-1 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-10">
-                  <button 
-                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
-                  >
-                    <Edit className="h-4 w-4 mr-2" />
-                    Edit
-                  </button>
-                  <button 
-                    onClick={handleDelete}
-                    disabled={deleteMutation.isPending}
-                    className="flex items-center w-full px-4 py-2 text-sm text-error-600 hover:bg-error-50 disabled:opacity-50"
-                  >
-                    <Trash2 className="h-4 w-4 mr-2" />
-                    {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
-                  </button>
-                </div>
-              )}
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <span className={cn(
+                'status-badge',
+                connector.is_enabled ? 'status-active' : 'status-inactive'
+              )}>
+                {connector.is_enabled ? 'Enabled' : 'Disabled'}
+              </span>
+
+              <button
+                onClick={() => toggleMutation.mutate()}
+                disabled={toggleMutation.isPending}
+                className="p-1 hover:bg-gray-100 rounded disabled:opacity-50"
+              >
+                {connector.is_enabled ? (
+                  <ToggleRight className="h-5 w-5 text-success-600" />
+                ) : (
+                  <ToggleLeft className="h-5 w-5 text-gray-400" />
+                )}
+              </button>
+
+              <div className="relative">
+                <button
+                  onClick={() => setShowMenu(!showMenu)}
+                  className="p-1 hover:bg-gray-100 rounded"
+                >
+                  <MoreVertical className="h-4 w-4 text-gray-400" />
+                </button>
+
+                {showMenu && (
+                  <div className="absolute right-0 mt-1 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-10">
+                    <button
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                    >
+                      <Edit className="h-4 w-4 mr-2" />
+                      Edit
+                    </button>
+                    <button
+                      onClick={handleDelete}
+                      disabled={deleteMutation.isPending}
+                      className="flex items-center w-full px-4 py-2 text-sm text-error-600 hover:bg-error-50 disabled:opacity-50"
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+                    </button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
- Replace inline URL display with "Connection Info" button to prevent overflow
- Add comprehensive modal showing WebSocket and HTTP URLs with copy buttons
- Include Claude Desktop setup instructions with mcp-remote configuration
- Show conditional PATH setup only when npx is not in system PATH
- Add ngrok setup instructions for localhost environments
- Include config file locations for macOS and Windows


<img width="1307" height="934" alt="Screenshot 2025-10-12 at 12 40 17 PM" src="https://github.com/user-attachments/assets/79415c51-845a-449e-8eac-eed3db0bc5aa" />
