### PR TITLE
Add PUBLIC_URL support for OAuth with ngrok and Slack integration

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -158,12 +158,12 @@ jobs:
         echo "DATABASE_URL=postgresql://sage_mcp:sage_mcp_password@postgres:5432/sage_mcp" > .env
         echo "SECRET_KEY=test-secret-key" >> .env
         echo "ENVIRONMENT=test" >> .env
-        docker-compose config
-        docker-compose up -d --build
+        docker compose config
+        docker compose up -d --build
         sleep 30
         curl -f http://localhost:8000/health
         curl -f http://localhost:3000
-        docker-compose down -v
+        docker compose down -v
 
   comment-coverage:
     name: Comment Coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - DATABASE_URL=postgresql://sage_mcp:password@postgres:5432/sage_mcp
       - SECRET_KEY=dev-secret-key-change-in-production
       - BASE_URL=http://localhost:8000
+      - PUBLIC_URL=${PUBLIC_URL:-}
       # OAuth settings (set these with your actual values)
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -215,3 +215,116 @@ class TestOAuthAPI:
         if response.status_code in [307, 302, 303]:
             assert "location" in response.headers
             assert "github.com" in response.headers["location"]
+
+    def test_create_oauth_config(self, client: TestClient):
+        """Test creating OAuth configuration for a tenant."""
+        # Create a tenant first
+        tenant_data = {
+            "slug": "oauth-config-tenant",
+            "name": "OAuth Config Tenant",
+            "description": "A tenant for OAuth config testing",
+            "contact_email": "oauthconfig@example.com"
+        }
+        tenant_response = client.post("/api/v1/admin/tenants", json=tenant_data)
+        assert tenant_response.status_code == 201
+
+        # Create OAuth config
+        oauth_config = {
+            "provider": "slack",
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret"
+        }
+        response = client.post(
+            "/api/v1/oauth/oauth-config-tenant/config",
+            json=oauth_config
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["provider"] == "slack"
+        assert data["client_id"] == "test-client-id"
+        assert data["is_active"] is True
+
+    def test_list_oauth_configs(self, client: TestClient):
+        """Test listing OAuth configurations for a tenant."""
+        # Create a tenant first
+        tenant_data = {
+            "slug": "oauth-list-config-tenant",
+            "name": "OAuth List Config Tenant",
+            "description": "A tenant for OAuth config listing",
+            "contact_email": "oauthlistconfig@example.com"
+        }
+        tenant_response = client.post("/api/v1/admin/tenants", json=tenant_data)
+        assert tenant_response.status_code == 201
+
+        # Create OAuth config
+        oauth_config = {
+            "provider": "github",
+            "client_id": "test-github-client-id",
+            "client_secret": "test-github-client-secret"
+        }
+        client.post(
+            "/api/v1/oauth/oauth-list-config-tenant/config",
+            json=oauth_config
+        )
+
+        # List OAuth configs
+        response = client.get("/api/v1/oauth/oauth-list-config-tenant/config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert data[0]["provider"] == "github"
+
+    def test_delete_oauth_config(self, client: TestClient):
+        """Test deleting OAuth configuration."""
+        # Create a tenant first
+        tenant_data = {
+            "slug": "oauth-delete-config-tenant",
+            "name": "OAuth Delete Config Tenant",
+            "description": "A tenant for OAuth config deletion",
+            "contact_email": "oauthdeleteconfig@example.com"
+        }
+        tenant_response = client.post("/api/v1/admin/tenants", json=tenant_data)
+        assert tenant_response.status_code == 201
+
+        # Create OAuth config
+        oauth_config = {
+            "provider": "slack",
+            "client_id": "test-delete-client-id",
+            "client_secret": "test-delete-client-secret"
+        }
+        client.post(
+            "/api/v1/oauth/oauth-delete-config-tenant/config",
+            json=oauth_config
+        )
+
+        # Delete OAuth config
+        response = client.delete(
+            "/api/v1/oauth/oauth-delete-config-tenant/config/slack"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "deleted successfully" in data["message"]
+
+    def test_list_oauth_credentials(self, client: TestClient):
+        """Test listing OAuth credentials for a tenant."""
+        # Create a tenant first
+        tenant_data = {
+            "slug": "oauth-creds-tenant",
+            "name": "OAuth Creds Tenant",
+            "description": "A tenant for OAuth credentials testing",
+            "contact_email": "oauthcreds@example.com"
+        }
+        tenant_response = client.post("/api/v1/admin/tenants", json=tenant_data)
+        assert tenant_response.status_code == 201
+
+        # List OAuth credentials (should be empty initially)
+        response = client.get("/api/v1/oauth/oauth-creds-tenant/auth")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)


### PR DESCRIPTION
This commit adds support for PUBLIC_URL environment variable to enable OAuth authentication with services like Slack that require HTTPS URLs and don't accept localhost for callback URLs.

Changes:
- Added PUBLIC_URL environment variable support in oauth.py
  - Updated initiate_oauth to check PUBLIC_URL first
  - Updated oauth_callback to use PUBLIC_URL for redirect URIs
  - Updated success redirect URL generation to use PUBLIC_URL
- Added PUBLIC_URL to docker-compose.yml environment variables
- Updated Slack OAuth scopes to include reactions:read and reactions:write
- Enhanced README.md with:
  - PUBLIC_URL configuration documentation
  - ngrok setup guide for OAuth testing
  - Complete Slack OAuth setup instructions
  - Required Slack bot token scopes documentation

This enables developers to test OAuth integrations locally with services that require public HTTPS URLs using tunneling services like ngrok.