### PR TITLE
Add Notion and Zoom connectors with architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,67 @@ Sage MCP is a production-ready platform that enables you to run multiple isolate
 - React-based management interface
 - Flexible database support (PostgreSQL, Supabase)
 
+## Architecture
+
+<div align="center">
+
+### High-Level System Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        CD[Claude Desktop]
+        WEB[Web Browser]
+    end
+
+    subgraph "SageMCP Platform"
+        subgraph "Frontend :3001"
+            UI[React UI]
+        end
+
+        subgraph "Backend :8000"
+            API[FastAPI]
+            MCP[MCP Server]
+            CONNECTORS[Connector Plugins<br/>GitHub • Jira • Slack<br/>Google Docs • Notion • Zoom]
+        end
+
+        subgraph "Database"
+            DB[(PostgreSQL/<br/>Supabase)]
+        end
+    end
+
+    subgraph "External Services"
+        EXT[GitHub • Slack • Jira<br/>Google • Notion • Zoom APIs]
+    end
+
+    CD -->|WebSocket/HTTP| MCP
+    WEB -->|HTTPS| UI
+    UI -->|REST API| API
+    MCP -->|Execute Tools| CONNECTORS
+    API -->|ORM| DB
+    CONNECTORS -->|OAuth| EXT
+
+    style CD fill:#e1f5ff
+    style WEB fill:#e1f5ff
+    style UI fill:#fff3e0
+    style API fill:#f3e5f5
+    style MCP fill:#e8f5e9
+    style CONNECTORS fill:#e8f5e9
+    style DB fill:#fce4ec
+    style EXT fill:#e0f2f1
+```
+
+**[📖 View Full Architecture Documentation →](docs/architecture.md)** | Includes 10+ detailed diagrams covering OAuth flows, multi-tenancy, database schema, deployment, and more.
+
+</div>
+
+**Architecture Highlights:**
+- **Multi-tenant isolation** with path-based routing (`/api/v1/{tenant_slug}/mcp`)
+- **Plugin-based connectors** for extensibility (6 connectors with 87+ tools)
+- **OAuth 2.0 authentication** per tenant with encrypted credential storage
+- **Async I/O** throughout the stack for high performance
+- **Horizontal scaling** ready via Kubernetes with Helm charts
+
 ### Built With
 
 * [FastAPI](https://fastapi.tiangolo.com/) - Backend framework
@@ -92,7 +153,9 @@ Add to your Claude Desktop config:
 
 Sage MCP provides production-ready connectors for popular development and collaboration tools. Each connector includes full OAuth 2.0 integration and comprehensive tool coverage.
 
-#### GitHub
+<div align="left">
+
+#### <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" width="24" height="24" style="vertical-align: middle;" /> GitHub
 **24 tools** for complete repository management
 - Repositories, issues, pull requests, and releases
 - Commits, branches, and comparisons
@@ -100,7 +163,7 @@ Sage MCP provides production-ready connectors for popular development and collab
 - User and organization management
 - [Full Documentation →](docs/connectors/github.md)
 
-#### Jira
+#### <img src="https://cdn.worldvectorlogo.com/logos/jira-1.svg" width="24" height="24" style="vertical-align: middle;" /> Jira
 **20 tools** for agile project management
 - Issue creation, updates, and JQL search
 - Sprint and board management
@@ -108,7 +171,7 @@ Sage MCP provides production-ready connectors for popular development and collab
 - Project and version tracking
 - [Full Documentation →](docs/connectors/jira.md)
 
-#### Slack
+#### <img src="https://cdn.worldvectorlogo.com/logos/slack-new-logo.svg" width="24" height="24" style="vertical-align: middle;" /> Slack
 **11 tools** for workspace communication
 - Send and read messages in channels
 - Thread conversations and search
@@ -116,7 +179,7 @@ Sage MCP provides production-ready connectors for popular development and collab
 - Emoji reactions and rich formatting
 - [Full Documentation →](docs/connectors/slack.md)
 
-#### Google Docs
+#### <img src="https://www.gstatic.com/images/branding/product/1x/docs_2020q4_48dp.png" width="24" height="24" style="vertical-align: middle;" /> Google Docs
 **10 tools** for document management
 - Create, read, and update documents
 - Search and list accessible documents
@@ -124,9 +187,26 @@ Sage MCP provides production-ready connectors for popular development and collab
 - Manage sharing permissions
 - [Full Documentation →](docs/connectors/google-docs.md)
 
+#### <img src="https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png" width="24" height="24" style="vertical-align: middle;" /> Notion
+**10 tools** for workspace collaboration
+- Access databases, pages, and blocks
+- Search and query database entries
+- Create and update pages with content
+- Read structured and plain text content
+- [Full Documentation →](docs/connectors/notion.md)
+
+#### <img src="https://st1.zoom.us/static/5.17.11.2992/image/new/ZoomLogo.png" width="64" height="24" style="vertical-align: middle;" /> Zoom
+**12 tools** for video conferencing
+- Manage meetings, webinars, and recordings
+- Create and update scheduled meetings
+- Access cloud recordings and download links
+- View meeting participants and invitations
+- [Full Documentation →](docs/connectors/zoom.md)
+
+</div>
+
 **Coming Soon**
 - GitLab
-- Notion
 - Linear
 - Confluence
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,684 @@
+# SageMCP Architecture
+
+## High-Level System Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        CD[Claude Desktop]
+        WEB[Web Browser]
+    end
+
+    subgraph "SageMCP Platform"
+        subgraph "Frontend - React App :3001"
+            UI[React UI]
+            PAGES[Pages: Dashboard, Tenants, Connectors]
+            COMP[Components: Modals, Forms]
+        end
+
+        subgraph "Backend - FastAPI :8000"
+            API[FastAPI Application]
+
+            subgraph "API Routes"
+                ADMIN[Admin API<br/>/api/v1/admin/*]
+                OAUTH[OAuth API<br/>/api/v1/oauth/*]
+                MCP_ROUTE[MCP API<br/>/api/v1/{slug}/mcp]
+            end
+
+            subgraph "Core Services"
+                MCP_SERVER[MCP Server]
+                MCP_TRANSPORT[MCP Transport<br/>WebSocket/HTTP/SSE]
+            end
+
+            subgraph "Connector System"
+                REGISTRY[Connector Registry]
+                BASE[Base Connector]
+
+                subgraph "Connector Plugins"
+                    GH[GitHub<br/>24 tools]
+                    JIRA[Jira<br/>20 tools]
+                    SLACK[Slack<br/>11 tools]
+                    GDOCS[Google Docs<br/>10 tools]
+                    NOTION[Notion<br/>10 tools]
+                    ZOOM[Zoom<br/>12 tools]
+                end
+            end
+
+            subgraph "Data Layer"
+                ORM[SQLAlchemy ORM]
+                DB_MGR[Database Manager]
+            end
+        end
+
+        subgraph "Database"
+            DB[(PostgreSQL/<br/>Supabase)]
+
+            subgraph "Tables"
+                T_TENANT[Tenants]
+                T_CONN[Connectors]
+                T_OAUTH[OAuth Credentials]
+                T_CONFIG[OAuth Configs]
+            end
+        end
+    end
+
+    subgraph "External Services"
+        GITHUB_API[GitHub API]
+        SLACK_API[Slack API]
+        JIRA_API[Jira API]
+        GOOGLE_API[Google APIs]
+        NOTION_API[Notion API]
+        ZOOM_API[Zoom API]
+    end
+
+    %% Client connections
+    CD -->|WebSocket/HTTP| MCP_ROUTE
+    WEB -->|HTTP| UI
+
+    %% Frontend to Backend
+    UI -->|REST API| ADMIN
+    UI -->|REST API| OAUTH
+    UI -->|WebSocket Test| MCP_ROUTE
+
+    %% API routing
+    ADMIN -->|Manage| ORM
+    OAUTH -->|Auth Flow| ORM
+    MCP_ROUTE -->|Protocol| MCP_TRANSPORT
+
+    %% MCP flow
+    MCP_TRANSPORT -->|Initialize| MCP_SERVER
+    MCP_SERVER -->|Get Tools| REGISTRY
+    MCP_SERVER -->|Execute| REGISTRY
+
+    %% Connector registry
+    REGISTRY -->|Manage| BASE
+    BASE -.->|Implements| GH
+    BASE -.->|Implements| JIRA
+    BASE -.->|Implements| SLACK
+    BASE -.->|Implements| GDOCS
+    BASE -.->|Implements| NOTION
+    BASE -.->|Implements| ZOOM
+
+    %% Database connections
+    ORM -->|Async Queries| DB_MGR
+    DB_MGR -->|Connection Pool| DB
+
+    DB -->|Store| T_TENANT
+    DB -->|Store| T_CONN
+    DB -->|Store| T_OAUTH
+    DB -->|Store| T_CONFIG
+
+    %% External API calls
+    GH -->|REST API| GITHUB_API
+    JIRA -->|REST API| JIRA_API
+    SLACK -->|REST API| SLACK_API
+    GDOCS -->|REST API| GOOGLE_API
+    NOTION -->|REST API| NOTION_API
+    ZOOM -->|REST API| ZOOM_API
+
+    style CD fill:#e1f5ff
+    style WEB fill:#e1f5ff
+    style UI fill:#fff3e0
+    style API fill:#f3e5f5
+    style MCP_SERVER fill:#e8f5e9
+    style REGISTRY fill:#e8f5e9
+    style DB fill:#fce4ec
+```
+
+## Multi-Tenant Architecture
+
+```mermaid
+graph TB
+    subgraph "Tenant 1: acme-corp"
+        T1[Tenant: acme-corp<br/>ID: uuid-1]
+        T1_CONN1[Connector: GitHub<br/>Enabled]
+        T1_CONN2[Connector: Slack<br/>Enabled]
+        T1_OAUTH1[OAuth: GitHub<br/>access_token]
+        T1_OAUTH2[OAuth: Slack<br/>access_token]
+
+        T1 --> T1_CONN1
+        T1 --> T1_CONN2
+        T1 --> T1_OAUTH1
+        T1 --> T1_OAUTH2
+        T1_CONN1 -.uses.-> T1_OAUTH1
+        T1_CONN2 -.uses.-> T1_OAUTH2
+    end
+
+    subgraph "Tenant 2: startup-inc"
+        T2[Tenant: startup-inc<br/>ID: uuid-2]
+        T2_CONN1[Connector: Jira<br/>Enabled]
+        T2_CONN2[Connector: Zoom<br/>Enabled]
+        T2_OAUTH1[OAuth: Jira<br/>access_token]
+        T2_OAUTH2[OAuth: Zoom<br/>access_token]
+
+        T2 --> T2_CONN1
+        T2 --> T2_CONN2
+        T2 --> T2_OAUTH1
+        T2 --> T2_OAUTH2
+        T2_CONN1 -.uses.-> T2_OAUTH1
+        T2_CONN2 -.uses.-> T2_OAUTH2
+    end
+
+    CD1[Claude Desktop<br/>Tenant 1]
+    CD2[Claude Desktop<br/>Tenant 2]
+
+    CD1 -->|WS: /api/v1/acme-corp/connectors/{id}/mcp| T1
+    CD2 -->|WS: /api/v1/startup-inc/connectors/{id}/mcp| T2
+
+    style T1 fill:#e3f2fd
+    style T2 fill:#f3e5f5
+    style CD1 fill:#e1f5ff
+    style CD2 fill:#e1f5ff
+```
+
+## OAuth Authentication Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Frontend
+    participant SageMCP
+    participant Provider as OAuth Provider<br/>(GitHub/Slack/etc)
+    participant API as External API
+
+    User->>Frontend: Click "Connect GitHub"
+    Frontend->>SageMCP: POST /api/v1/oauth/github/auth
+    SageMCP->>SageMCP: Generate state token
+    SageMCP->>Frontend: Redirect URL with state
+    Frontend->>Provider: Redirect to OAuth authorization
+    Provider->>User: Show authorization page
+    User->>Provider: Approve permissions
+    Provider->>SageMCP: Redirect with auth code
+    SageMCP->>Provider: Exchange code for token
+    Provider->>SageMCP: Return access_token & refresh_token
+    SageMCP->>SageMCP: Store OAuthCredential in DB
+    SageMCP->>Frontend: Redirect to /oauth/success
+    Frontend->>User: Show success message
+
+    Note over SageMCP,API: Later: MCP Tool Execution
+    User->>SageMCP: Execute tool via MCP
+    SageMCP->>SageMCP: Load OAuth credential
+    SageMCP->>API: Call API with access_token
+    API->>SageMCP: Return data
+    SageMCP->>User: Return MCP response
+```
+
+## MCP Tool Execution Flow
+
+```mermaid
+sequenceDiagram
+    participant Client as Claude Desktop
+    participant Transport as MCP Transport
+    participant Server as MCP Server
+    participant Registry as Connector Registry
+    participant Connector as Connector Plugin
+    participant DB as Database
+    participant API as External API
+
+    Client->>Transport: WebSocket Connect<br/>/api/v1/{slug}/connectors/{id}/mcp
+    Transport->>DB: Load Tenant & Connector
+    DB->>Transport: Return config
+    Transport->>Server: Initialize MCP Server
+
+    Client->>Server: list_tools()
+    Server->>Registry: Get connector by type
+    Registry->>Connector: get_tools()
+    Connector->>Server: Return tool definitions
+    Server->>Client: Tool list
+
+    Client->>Server: call_tool("github_list_repositories", args)
+    Server->>Registry: Get GitHub connector
+    Registry->>Connector: execute_tool(name, args, oauth)
+    Connector->>DB: Validate OAuth credential
+    DB->>Connector: OAuth token valid
+    Connector->>API: GET /user/repos<br/>Authorization: Bearer {token}
+    API->>Connector: Repository list
+    Connector->>Server: Format as TextContent
+    Server->>Client: MCP response with data
+```
+
+## Database Schema
+
+```mermaid
+erDiagram
+    TENANT ||--o{ CONNECTOR : has
+    TENANT ||--o{ OAUTH_CREDENTIAL : has
+    TENANT ||--o{ OAUTH_CONFIG : has
+
+    TENANT {
+        uuid id PK
+        string slug UK
+        string name
+        string description
+        boolean is_active
+        string contact_email
+        json settings
+        datetime created_at
+        datetime updated_at
+    }
+
+    CONNECTOR {
+        uuid id PK
+        uuid tenant_id FK
+        enum connector_type
+        string name
+        string description
+        boolean is_enabled
+        json configuration
+        datetime created_at
+        datetime updated_at
+    }
+
+    OAUTH_CREDENTIAL {
+        uuid id PK
+        uuid tenant_id FK
+        string provider
+        string provider_user_id
+        string provider_username
+        text access_token
+        text refresh_token
+        datetime expires_at
+        string scopes
+        string provider_data
+        boolean is_active
+        datetime created_at
+        datetime updated_at
+    }
+
+    OAUTH_CONFIG {
+        uuid id PK
+        uuid tenant_id FK
+        string provider
+        string client_id
+        string client_secret
+        boolean is_active
+        datetime created_at
+        datetime updated_at
+    }
+```
+
+## Connector Plugin Architecture
+
+```mermaid
+graph TB
+    subgraph "Connector Registry"
+        REG[ConnectorRegistry<br/>Singleton]
+        REG_MAP{Connector Map}
+
+        REG --> REG_MAP
+    end
+
+    subgraph "Base Class"
+        BASE[BaseConnector<br/>Abstract Class]
+
+        BASE_PROPS[Properties:<br/>- name<br/>- display_name<br/>- requires_oauth]
+        BASE_METHODS[Methods:<br/>- get_tools<br/>- get_resources<br/>- execute_tool<br/>- read_resource<br/>- validate_oauth]
+
+        BASE --> BASE_PROPS
+        BASE --> BASE_METHODS
+    end
+
+    subgraph "Connector Implementations"
+        GH_CONN[GitHubConnector]
+        JIRA_CONN[JiraConnector]
+        SLACK_CONN[SlackConnector]
+        NOTION_CONN[NotionConnector]
+        ZOOM_CONN[ZoomConnector]
+
+        GH_CONN --> GH_TOOLS["24 Tools:<br/>- list_repositories<br/>- create_issue<br/>- list_pull_requests<br/>- etc."]
+        JIRA_CONN --> JIRA_TOOLS["20 Tools:<br/>- search_issues<br/>- create_issue<br/>- list_projects<br/>- etc."]
+        SLACK_CONN --> SLACK_TOOLS["11 Tools:<br/>- send_message<br/>- list_channels<br/>- search_messages<br/>- etc."]
+        NOTION_CONN --> NOTION_TOOLS["10 Tools:<br/>- list_databases<br/>- get_page<br/>- create_page<br/>- etc."]
+        ZOOM_CONN --> ZOOM_TOOLS["12 Tools:<br/>- list_meetings<br/>- create_meeting<br/>- list_recordings<br/>- etc."]
+    end
+
+    REG_MAP -->|"github"| GH_CONN
+    REG_MAP -->|"jira"| JIRA_CONN
+    REG_MAP -->|"slack"| SLACK_CONN
+    REG_MAP -->|"notion"| NOTION_CONN
+    REG_MAP -->|"zoom"| ZOOM_CONN
+
+    BASE -.->|inherits| GH_CONN
+    BASE -.->|inherits| JIRA_CONN
+    BASE -.->|inherits| SLACK_CONN
+    BASE -.->|inherits| NOTION_CONN
+    BASE -.->|inherits| ZOOM_CONN
+
+    style REG fill:#e8f5e9
+    style BASE fill:#fff3e0
+    style GH_CONN fill:#e3f2fd
+    style JIRA_CONN fill:#e3f2fd
+    style SLACK_CONN fill:#e3f2fd
+    style NOTION_CONN fill:#e3f2fd
+    style ZOOM_CONN fill:#e3f2fd
+```
+
+## Request Flow: Creating and Using a Connector
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Admin as Admin User
+    participant UI as Web UI
+    participant API as FastAPI Backend
+    participant DB as PostgreSQL
+    participant Provider as OAuth Provider
+    participant Claude as Claude Desktop
+    participant Connector as Connector Plugin
+    participant ExtAPI as External API
+
+    Note over Admin,DB: Step 1: Create Tenant
+    Admin->>UI: Create tenant "acme-corp"
+    UI->>API: POST /api/v1/admin/tenants
+    API->>DB: INSERT INTO tenants
+    DB->>API: Tenant created
+    API->>UI: Return tenant data
+
+    Note over Admin,Provider: Step 2: Setup OAuth
+    Admin->>UI: Configure GitHub OAuth
+    UI->>API: POST /api/v1/oauth/github/auth
+    API->>Provider: Redirect to authorization
+    Provider->>Admin: Show authorization page
+    Admin->>Provider: Approve
+    Provider->>API: Callback with auth code
+    API->>Provider: Exchange code for token
+    Provider->>API: Return access_token
+    API->>DB: INSERT INTO oauth_credentials
+    API->>UI: OAuth success
+
+    Note over Admin,DB: Step 3: Create Connector
+    Admin->>UI: Add GitHub connector
+    UI->>API: POST /api/v1/admin/tenants/{id}/connectors
+    API->>DB: INSERT INTO connectors
+    DB->>API: Connector created
+    API->>UI: Connector ready
+
+    Note over Claude,ExtAPI: Step 4: Use MCP Tools
+    Claude->>API: WebSocket connect<br/>/api/v1/acme-corp/connectors/{id}/mcp
+    API->>DB: Load tenant, connector, oauth
+    DB->>API: Return configuration
+    API->>Claude: WebSocket connected
+
+    Claude->>API: call_tool("github_list_repositories")
+    API->>Connector: execute_tool()
+    Connector->>DB: Get OAuth credential
+    DB->>Connector: access_token
+    Connector->>ExtAPI: GET /user/repos<br/>Bearer {token}
+    ExtAPI->>Connector: Repository list JSON
+    Connector->>API: Format response
+    API->>Claude: MCP TextContent response
+```
+
+## Technology Stack
+
+```mermaid
+graph LR
+    subgraph "Frontend Stack"
+        REACT[React 18]
+        TS[TypeScript]
+        VITE[Vite]
+        RR[React Router]
+        TAILWIND[Tailwind CSS]
+
+        REACT --> TS
+        REACT --> VITE
+        REACT --> RR
+        REACT --> TAILWIND
+    end
+
+    subgraph "Backend Stack"
+        FASTAPI[FastAPI]
+        PYTHON[Python 3.11+]
+        SA[SQLAlchemy 2.0]
+        PYDANTIC[Pydantic v2]
+        MCP_SDK[MCP SDK]
+        HTTPX[HTTPX]
+
+        FASTAPI --> PYTHON
+        FASTAPI --> SA
+        FASTAPI --> PYDANTIC
+        FASTAPI --> MCP_SDK
+        FASTAPI --> HTTPX
+    end
+
+    subgraph "Database Stack"
+        POSTGRES[PostgreSQL 15]
+        SUPABASE[Supabase]
+        ASYNCPG[AsyncPG]
+
+        POSTGRES -.alternative.-> SUPABASE
+        SA --> ASYNCPG
+        ASYNCPG --> POSTGRES
+        ASYNCPG --> SUPABASE
+    end
+
+    subgraph "DevOps Stack"
+        DOCKER[Docker]
+        DC[Docker Compose]
+        K8S[Kubernetes]
+        HELM[Helm Charts]
+
+        DOCKER --> DC
+        K8S --> HELM
+    end
+
+    subgraph "Testing Stack"
+        PYTEST[Pytest]
+        PYTEST_ASYNC[pytest-asyncio]
+        MOCK[unittest.mock]
+
+        PYTEST --> PYTEST_ASYNC
+        PYTEST --> MOCK
+    end
+
+    style REACT fill:#61dafb
+    style FASTAPI fill:#009688
+    style POSTGRES fill:#336791
+    style DOCKER fill:#2496ed
+    style PYTEST fill:#0a9edc
+```
+
+## Deployment Architecture
+
+```mermaid
+graph TB
+    subgraph "Kubernetes Cluster"
+        subgraph "Ingress"
+            ING[Ingress Controller<br/>NGINX/Traefik]
+        end
+
+        subgraph "Application Pods"
+            FE1[Frontend Pod 1<br/>React:3001]
+            FE2[Frontend Pod 2<br/>React:3001]
+            BE1[Backend Pod 1<br/>FastAPI:8000]
+            BE2[Backend Pod 2<br/>FastAPI:8000]
+            BE3[Backend Pod 3<br/>FastAPI:8000]
+        end
+
+        subgraph "Services"
+            FE_SVC[Frontend Service<br/>ClusterIP]
+            BE_SVC[Backend Service<br/>ClusterIP]
+        end
+
+        subgraph "Configuration"
+            CM[ConfigMap<br/>- API URLs<br/>- Feature flags]
+            SEC[Secrets<br/>- OAuth credentials<br/>- DB password<br/>- SECRET_KEY]
+        end
+    end
+
+    subgraph "Managed Services"
+        DB_MANAGED[Managed PostgreSQL<br/>or Supabase]
+        REDIS[Redis Cache<br/>Optional]
+    end
+
+    USERS[Users/Clients]
+
+    USERS -->|HTTPS| ING
+    ING -->|Route /| FE_SVC
+    ING -->|Route /api| BE_SVC
+
+    FE_SVC --> FE1
+    FE_SVC --> FE2
+
+    BE_SVC --> BE1
+    BE_SVC --> BE2
+    BE_SVC --> BE3
+
+    BE1 --> CM
+    BE1 --> SEC
+    BE2 --> CM
+    BE2 --> SEC
+    BE3 --> CM
+    BE3 --> SEC
+
+    BE1 -->|Connection Pool| DB_MANAGED
+    BE2 -->|Connection Pool| DB_MANAGED
+    BE3 -->|Connection Pool| DB_MANAGED
+
+    BE1 -.->|Optional| REDIS
+    BE2 -.->|Optional| REDIS
+    BE3 -.->|Optional| REDIS
+
+    style ING fill:#ff9800
+    style FE_SVC fill:#4caf50
+    style BE_SVC fill:#4caf50
+    style DB_MANAGED fill:#2196f3
+    style REDIS fill:#f44336
+```
+
+## Key Design Patterns
+
+### 1. **Plugin Architecture**
+- Connectors are dynamically registered via decorators
+- All connectors inherit from `BaseConnector` abstract class
+- Registry pattern for connector discovery and instantiation
+
+### 2. **Multi-Tenancy**
+- Path-based tenant isolation (`/api/v1/{tenant_slug}`)
+- Foreign key relationships ensure data segregation
+- Each tenant has isolated OAuth credentials and connectors
+
+### 3. **Repository Pattern**
+- SQLAlchemy ORM abstracts database operations
+- Async database access via `asyncpg`
+- Connection pooling for performance
+
+### 4. **Factory Pattern**
+- `MCPServer` factory creates server instances per request
+- Connector factory creates connector instances from registry
+
+### 5. **Decorator Pattern**
+- `@register_connector` decorator for plugin registration
+- FastAPI route decorators for API endpoints
+
+### 6. **Adapter Pattern**
+- Connectors adapt external APIs to MCP protocol
+- Each connector translates between MCP tools and provider-specific APIs
+
+## Security Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Layers"
+        subgraph "Network Security"
+            HTTPS[HTTPS/TLS]
+            CORS[CORS Middleware]
+        end
+
+        subgraph "Authentication"
+            OAUTH[OAuth 2.0 Flow]
+            JWT[JWT Tokens<br/>Optional]
+            STATE[State Token<br/>CSRF Protection]
+        end
+
+        subgraph "Authorization"
+            TENANT_ISO[Tenant Isolation<br/>Path-based]
+            FK_CHECK[Foreign Key<br/>Constraints]
+        end
+
+        subgraph "Data Protection"
+            TOKEN_ENC[Token Encryption<br/>at rest]
+            SECRET_MGR[Secret Management<br/>K8s Secrets/Vault]
+            ENV_VAR[Environment Variables]
+        end
+
+        subgraph "Input Validation"
+            PYDANTIC[Pydantic Models]
+            SQL_PREVENT[SQLAlchemy ORM<br/>SQL Injection Prevention]
+        end
+    end
+
+    HTTPS --> OAUTH
+    CORS --> OAUTH
+    OAUTH --> STATE
+    STATE --> TENANT_ISO
+    TENANT_ISO --> FK_CHECK
+    FK_CHECK --> TOKEN_ENC
+    TOKEN_ENC --> SECRET_MGR
+    SECRET_MGR --> ENV_VAR
+    ENV_VAR --> PYDANTIC
+    PYDANTIC --> SQL_PREVENT
+```
+
+## Performance Considerations
+
+### Connection Pooling
+- SQLAlchemy async engine with connection pool (default: 5-20 connections)
+- HTTPX async client for external API calls
+- WebSocket connection reuse for MCP protocol
+
+### Caching Strategy (Optional)
+- Redis for session data
+- In-memory connector registry (singleton)
+- OAuth token caching with TTL
+
+### Scalability
+- Horizontal scaling via Kubernetes replicas
+- Stateless backend design (WebSocket state in transport layer)
+- Database connection pooling
+- Async I/O throughout the stack
+
+## Monitoring & Observability
+
+```mermaid
+graph LR
+    subgraph "Application"
+        APP[SageMCP Backend]
+    end
+
+    subgraph "Metrics & Logs"
+        METRICS[Prometheus Metrics<br/>- Request count<br/>- Response time<br/>- Error rate]
+        LOGS[Structured Logs<br/>- JSON format<br/>- Log levels]
+        TRACES[Distributed Tracing<br/>Optional: Jaeger/OTEL]
+    end
+
+    subgraph "Monitoring"
+        PROM[Prometheus]
+        GRAF[Grafana]
+        ALERT[AlertManager]
+    end
+
+    APP --> METRICS
+    APP --> LOGS
+    APP --> TRACES
+
+    METRICS --> PROM
+    PROM --> GRAF
+    PROM --> ALERT
+
+    LOGS --> GRAF
+```
+
+---
+
+## Summary
+
+SageMCP is a **multi-tenant MCP server platform** that enables Claude Desktop to connect to external services via OAuth-authenticated connectors. The architecture is:
+
+- **Modular**: Plugin-based connector system
+- **Scalable**: Async I/O, connection pooling, horizontal scaling
+- **Secure**: OAuth 2.0, tenant isolation, token encryption
+- **Extensible**: Easy to add new connectors following the base pattern
+- **Production-ready**: Docker/Kubernetes deployment, comprehensive testing
+
+The platform successfully bridges Claude Desktop's MCP protocol with external service APIs (GitHub, Slack, Jira, Google Docs, Notion, Zoom) through a unified, tenant-aware interface.

--- a/docs/connectors/notion.md
+++ b/docs/connectors/notion.md
@@ -1,0 +1,637 @@
+# Notion Connector
+
+The Notion connector provides comprehensive integration with Notion API, enabling access to Notion databases, pages, and blocks through OAuth 2.0 authentication.
+
+## Features
+
+- **10 comprehensive tools** covering page, database, and block management
+- **Full OAuth 2.0 authentication** with Notion
+- **Dynamic resource discovery** of pages and databases
+- **Real-time access** to content and metadata
+- **Support for creating and updating content**
+
+## OAuth Setup
+
+### Prerequisites
+
+- A Notion account
+- Access to create Notion integrations
+
+### Step-by-Step Configuration
+
+1. **Create Notion Integration**
+   - Go to [Notion Integrations](https://www.notion.so/my-integrations)
+   - Click "New integration"
+   - Fill in the basic information:
+     - **Name**: `SageMCP` (or your preferred name)
+     - **Associated workspace**: Select your workspace
+     - **Logo**: Optional
+   - Click "Submit"
+
+2. **Configure Integration Capabilities**
+   - Under "Capabilities", ensure the following are enabled:
+     - **Read content**: ✓
+     - **Update content**: ✓
+     - **Insert content**: ✓
+   - Under "User Capabilities", enable:
+     - **Read user information including email addresses**: ✓
+
+3. **Get Integration Credentials**
+   - After creating the integration, you'll see the **Integration Token**
+   - Copy the **Internal Integration Token** (starts with `secret_`)
+   - Note: For OAuth 2.0 flow, you'll need:
+     - **OAuth client ID**
+     - **OAuth client secret**
+   - These are found under "Distribution" → "OAuth Domain & URIs"
+
+4. **Configure OAuth Settings**
+   - Under "Distribution" → "OAuth Domain & URIs":
+     - **Redirect URIs**: Add `http://localhost:8000/api/v1/oauth/callback/notion`
+     - **Configuration URL**: Optional
+   - Click "Submit"
+
+5. **Update Environment Variables**
+
+   Add the following to your `.env` file:
+
+   ```env
+   NOTION_CLIENT_ID=your_oauth_client_id_here
+   NOTION_CLIENT_SECRET=your_oauth_client_secret_here
+   ```
+
+6. **Connect Pages and Databases**
+   - In Notion, navigate to the page or database you want to access
+   - Click the "..." menu in the top right
+   - Select "Add connections"
+   - Search for and select your integration name (e.g., "SageMCP")
+   - Click "Confirm"
+
+### Required Scopes
+
+The Notion connector requires the following OAuth scopes:
+
+- No explicit scopes needed - Notion uses integration capabilities instead
+- The integration needs to be explicitly connected to pages/databases
+
+## Available Tools
+
+### 1. notion_list_databases
+
+List all Notion databases accessible to the integration.
+
+**Parameters:**
+- `page_size` (optional, integer, default: 20): Number of databases to return (max 100)
+
+**Example:**
+```json
+{
+  "page_size": 50
+}
+```
+
+**Response:**
+```json
+{
+  "databases": [
+    {
+      "id": "database-id",
+      "title": "My Database",
+      "created_time": "2024-01-01T00:00:00Z",
+      "last_edited_time": "2024-01-02T00:00:00Z",
+      "url": "https://notion.so/database-id"
+    }
+  ],
+  "count": 1,
+  "has_more": false
+}
+```
+
+### 2. notion_search
+
+Search for pages and databases by title.
+
+**Parameters:**
+- `query` (required, string): Search query to match against titles
+- `filter` (optional, enum: "page" | "database"): Filter results by type
+- `page_size` (optional, integer, default: 20): Number of results to return (max 100)
+
+**Example:**
+```json
+{
+  "query": "project notes",
+  "filter": "page",
+  "page_size": 20
+}
+```
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "id": "page-id",
+      "type": "page",
+      "title": "Project Notes 2024",
+      "created_time": "2024-01-01T00:00:00Z",
+      "last_edited_time": "2024-01-02T00:00:00Z",
+      "url": "https://notion.so/page-id"
+    }
+  ],
+  "count": 1,
+  "has_more": false
+}
+```
+
+### 3. notion_get_page
+
+Get a Notion page by ID, including metadata and properties.
+
+**Parameters:**
+- `page_id` (required, string): The ID of the page to retrieve
+
+**Example:**
+```json
+{
+  "page_id": "abc123-def456-ghi789"
+}
+```
+
+**Response:**
+```json
+{
+  "id": "abc123-def456-ghi789",
+  "created_time": "2024-01-01T00:00:00Z",
+  "last_edited_time": "2024-01-02T00:00:00Z",
+  "archived": false,
+  "url": "https://notion.so/abc123-def456-ghi789",
+  "properties": {
+    "title": { ... }
+  }
+}
+```
+
+### 4. notion_get_page_content
+
+Get the content blocks of a Notion page.
+
+**Parameters:**
+- `page_id` (required, string): The ID of the page to retrieve content from
+- `format` (optional, enum: "plain_text" | "structured", default: "plain_text"): Format of the output
+
+**Example:**
+```json
+{
+  "page_id": "abc123-def456-ghi789",
+  "format": "plain_text"
+}
+```
+
+**Response (plain_text):**
+```
+Title: My Page Title
+
+This is the first paragraph of content.
+
+This is a heading
+
+More content here.
+```
+
+**Response (structured):**
+```json
+{
+  "title": "My Page Title",
+  "page_id": "abc123-def456-ghi789",
+  "blocks": [
+    {
+      "type": "paragraph",
+      "paragraph": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": { "content": "This is the first paragraph of content." }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### 5. notion_get_database
+
+Get a Notion database by ID, including schema and properties.
+
+**Parameters:**
+- `database_id` (required, string): The ID of the database to retrieve
+
+**Example:**
+```json
+{
+  "database_id": "xyz789-abc123-def456"
+}
+```
+
+**Response:**
+```json
+{
+  "id": "xyz789-abc123-def456",
+  "title": "My Database",
+  "created_time": "2024-01-01T00:00:00Z",
+  "last_edited_time": "2024-01-02T00:00:00Z",
+  "url": "https://notion.so/xyz789-abc123-def456",
+  "properties": {
+    "Name": { "type": "title" },
+    "Status": { "type": "select" },
+    "Due Date": { "type": "date" }
+  }
+}
+```
+
+### 6. notion_query_database
+
+Query a Notion database to retrieve pages/entries.
+
+**Parameters:**
+- `database_id` (required, string): The ID of the database to query
+- `page_size` (optional, integer, default: 20): Number of results to return (max 100)
+
+**Example:**
+```json
+{
+  "database_id": "xyz789-abc123-def456",
+  "page_size": 50
+}
+```
+
+**Response:**
+```json
+{
+  "pages": [
+    {
+      "id": "page-id",
+      "title": "Task 1",
+      "created_time": "2024-01-01T00:00:00Z",
+      "last_edited_time": "2024-01-02T00:00:00Z",
+      "url": "https://notion.so/page-id",
+      "properties": {
+        "Name": { ... },
+        "Status": { ... }
+      }
+    }
+  ],
+  "count": 1,
+  "has_more": false
+}
+```
+
+### 7. notion_create_page
+
+Create a new page in a Notion database or as a child of another page.
+
+**Parameters:**
+- `parent_id` (required, string): The ID of the parent database or page
+- `parent_type` (optional, enum: "database_id" | "page_id", default: "database_id"): Type of parent
+- `title` (required, string): Title of the new page
+- `content` (optional, string): Optional plain text content to add to the page
+
+**Example:**
+```json
+{
+  "parent_id": "xyz789-abc123-def456",
+  "parent_type": "database_id",
+  "title": "New Task",
+  "content": "This is the initial content of the task."
+}
+```
+
+**Response:**
+```json
+{
+  "id": "new-page-id",
+  "url": "https://notion.so/new-page-id",
+  "created_time": "2024-01-03T00:00:00Z"
+}
+```
+
+### 8. notion_append_block_children
+
+Append blocks (content) to a page.
+
+**Parameters:**
+- `page_id` (required, string): The ID of the page to append content to
+- `content` (required, string): Plain text content to append to the page
+
+**Example:**
+```json
+{
+  "page_id": "abc123-def456-ghi789",
+  "content": "This is additional content to append to the page."
+}
+```
+
+**Response:**
+```json
+{
+  "status": "success",
+  "blocks_added": 1
+}
+```
+
+### 9. notion_update_page
+
+Update a page's properties (title, metadata).
+
+**Parameters:**
+- `page_id` (required, string): The ID of the page to update
+- `title` (required, string): New title for the page
+
+**Example:**
+```json
+{
+  "page_id": "abc123-def456-ghi789",
+  "title": "Updated Page Title"
+}
+```
+
+**Response:**
+```json
+{
+  "id": "abc123-def456-ghi789",
+  "url": "https://notion.so/abc123-def456-ghi789",
+  "last_edited_time": "2024-01-03T12:00:00Z"
+}
+```
+
+### 10. notion_get_block
+
+Get a specific block by ID.
+
+**Parameters:**
+- `block_id` (required, string): The ID of the block to retrieve
+
+**Example:**
+```json
+{
+  "block_id": "block-id-123"
+}
+```
+
+**Response:**
+```json
+{
+  "object": "block",
+  "id": "block-id-123",
+  "type": "paragraph",
+  "paragraph": {
+    "rich_text": [
+      {
+        "type": "text",
+        "text": { "content": "Block content" }
+      }
+    ]
+  }
+}
+```
+
+## Common Use Cases
+
+### 1. List All Databases
+
+```json
+{
+  "tool": "notion_list_databases",
+  "arguments": {
+    "page_size": 100
+  }
+}
+```
+
+### 2. Search for Specific Pages
+
+```json
+{
+  "tool": "notion_search",
+  "arguments": {
+    "query": "meeting notes",
+    "filter": "page"
+  }
+}
+```
+
+### 3. Read Page Content
+
+```json
+{
+  "tool": "notion_get_page_content",
+  "arguments": {
+    "page_id": "your-page-id",
+    "format": "plain_text"
+  }
+}
+```
+
+### 4. Query Database Entries
+
+```json
+{
+  "tool": "notion_query_database",
+  "arguments": {
+    "database_id": "your-database-id",
+    "page_size": 50
+  }
+}
+```
+
+### 5. Create a New Page in Database
+
+```json
+{
+  "tool": "notion_create_page",
+  "arguments": {
+    "parent_id": "database-id",
+    "parent_type": "database_id",
+    "title": "New Entry",
+    "content": "Initial content here"
+  }
+}
+```
+
+### 6. Append Content to Existing Page
+
+```json
+{
+  "tool": "notion_append_block_children",
+  "arguments": {
+    "page_id": "page-id",
+    "content": "Additional notes to append"
+  }
+}
+```
+
+## Error Handling
+
+The connector handles various error scenarios:
+
+### Invalid OAuth Credentials
+
+**Error:**
+```json
+{
+  "error": "Invalid or expired OAuth credentials"
+}
+```
+
+**Solution:** Re-authenticate with Notion through the OAuth flow.
+
+### HTTP Errors
+
+**Error:**
+```json
+{
+  "error": "HTTP error: 404",
+  "message": "Page not found"
+}
+```
+
+**Common HTTP Status Codes:**
+- `400`: Bad request - Invalid parameters
+- `401`: Unauthorized - Invalid or expired token
+- `403`: Forbidden - Integration doesn't have access to the resource
+- `404`: Not found - Resource doesn't exist
+- `429`: Rate limit exceeded
+
+**Solution:** Check the error message and ensure:
+1. The page/database ID is correct
+2. The integration has been connected to the resource
+3. You're not exceeding rate limits
+
+### Resource Not Connected
+
+**Error:**
+```json
+{
+  "error": "HTTP error: 403",
+  "message": "The integration doesn't have access to this resource"
+}
+```
+
+**Solution:** Connect the integration to the page/database:
+1. Open the page/database in Notion
+2. Click "..." → "Add connections"
+3. Select your integration
+4. Click "Confirm"
+
+## Limitations
+
+1. **Integration Access**: The integration must be explicitly connected to pages and databases before they can be accessed.
+
+2. **Rate Limits**: Notion API has rate limits:
+   - 3 requests per second
+   - Burst limit for short-term spikes
+
+3. **Content Types**: The connector currently supports basic block types:
+   - Paragraphs
+   - Headings (1, 2, 3)
+   - Lists (bulleted, numbered)
+   - To-do items
+   - Quotes
+   - Code blocks
+
+4. **Advanced Properties**: Complex database properties (formulas, rollups) are returned as-is in structured format but may not be fully parsed.
+
+5. **Pagination**: Large result sets require multiple requests using pagination cursors (not fully exposed in current implementation).
+
+## Tips and Best Practices
+
+### 1. Use Search Before Getting
+
+Instead of trying to guess page IDs, use `notion_search` to find pages first:
+
+```json
+{
+  "tool": "notion_search",
+  "arguments": {
+    "query": "quarterly report"
+  }
+}
+```
+
+### 2. Connect Your Integration
+
+Always remember to connect your integration to the pages/databases you want to access in Notion's UI.
+
+### 3. Use Plain Text Format for Reading
+
+For most reading use cases, `plain_text` format is easier to work with:
+
+```json
+{
+  "tool": "notion_get_page_content",
+  "arguments": {
+    "page_id": "page-id",
+    "format": "plain_text"
+  }
+}
+```
+
+### 4. Query Databases for Structured Data
+
+Use `notion_query_database` to get all entries from a database with their properties:
+
+```json
+{
+  "tool": "notion_query_database",
+  "arguments": {
+    "database_id": "database-id"
+  }
+}
+```
+
+### 5. Handle Rate Limits
+
+Implement exponential backoff when encountering rate limits (429 errors).
+
+## Troubleshooting
+
+### Can't Find My Pages/Databases
+
+**Problem:** `notion_list_databases` or `notion_search` returns empty results.
+
+**Solution:**
+1. Verify the integration is connected to the pages/databases in Notion
+2. Check that OAuth credentials are valid
+3. Ensure the integration has the correct capabilities enabled
+
+### Page Content is Empty
+
+**Problem:** `notion_get_page_content` returns empty content.
+
+**Solution:**
+1. The page might actually be empty
+2. Try using `format: "structured"` to see the raw block structure
+3. Check if the page has access restrictions
+
+### Can't Create Pages
+
+**Problem:** `notion_create_page` fails with 403 error.
+
+**Solution:**
+1. Verify the parent_id is correct
+2. Ensure the integration has "Insert content" capability
+3. Check that the integration is connected to the parent database/page
+
+## Additional Resources
+
+- [Notion API Documentation](https://developers.notion.com/)
+- [Notion API Reference](https://developers.notion.com/reference)
+- [Notion Integration Guide](https://developers.notion.com/docs/getting-started)
+- [Notion OAuth Guide](https://developers.notion.com/docs/authorization)
+
+## Support
+
+For issues or questions:
+1. Check the error message and this documentation
+2. Verify your OAuth setup is correct
+3. Ensure integrations are connected to resources
+4. Review Notion API documentation for additional details

--- a/docs/connectors/zoom.md
+++ b/docs/connectors/zoom.md
@@ -1,0 +1,764 @@
+# Zoom Connector
+
+The Zoom connector provides comprehensive integration with Zoom API, enabling access to meetings, webinars, recordings, and user management through OAuth 2.0 authentication.
+
+## Features
+
+- **12 comprehensive tools** covering meetings, webinars, recordings, and user management
+- **Full OAuth 2.0 authentication** with Zoom
+- **Dynamic resource discovery** of upcoming meetings
+- **Real-time access** to meeting details and recordings
+- **Support for creating and managing meetings**
+
+## OAuth Setup
+
+### Prerequisites
+
+- A Zoom account (Pro, Business, or Enterprise)
+- Access to Zoom Marketplace
+
+### Step-by-Step Configuration
+
+1. **Create a Zoom App**
+   - Go to [Zoom Marketplace](https://marketplace.zoom.us/)
+   - Click "Develop" → "Build App"
+   - Select "OAuth" app type
+   - Click "Create"
+
+2. **Configure App Information**
+   - **App Name**: `SageMCP` (or your preferred name)
+   - **Short Description**: Brief description of your app
+   - **Long Description**: Detailed description
+   - **Company Name**: Your company/organization name
+   - **Developer Contact Information**: Your email and name
+
+3. **Configure OAuth Settings**
+   - Under "App Credentials":
+     - Copy the **Client ID**
+     - Copy the **Client Secret**
+   - Under "Redirect URL for OAuth":
+     - Add: `http://localhost:8000/api/v1/oauth/callback/zoom`
+   - Under "OAuth allow list":
+     - Add: `http://localhost:8000`
+
+4. **Add Scopes**
+
+   Navigate to "Scopes" and add the following permissions:
+
+   **Meeting Scopes:**
+   - `meeting:read:admin` - View all user meetings
+   - `meeting:write:admin` - Create, update, and delete meetings
+   - `meeting:read:meeting_invitation:admin` - View meeting invitations
+
+   **Recording Scopes:**
+   - `recording:read:admin` - View all user recordings
+   - `recording:read:list_recording_files:admin` - List recording files
+
+   **User Scopes:**
+   - `user:read:admin` - View all user information
+
+   **Webinar Scopes:**
+   - `webinar:read:admin` - View all webinars
+   - `webinar:write:admin` - Create, update, and delete webinars
+
+   **Report Scopes:**
+   - `report:read:admin` - View meeting participants
+
+5. **Activation**
+   - Complete all required information
+   - Under "Activation", click "Activate your app"
+   - If developing for yourself, you can deactivate the app after installation
+
+6. **Update Environment Variables**
+
+   Add the following to your `.env` file:
+
+   ```env
+   ZOOM_CLIENT_ID=your_client_id_here
+   ZOOM_CLIENT_SECRET=your_client_secret_here
+   ```
+
+### Required Scopes
+
+The Zoom connector requires the following OAuth scopes:
+
+- `meeting:read:admin` - Read meeting information
+- `meeting:write:admin` - Create and manage meetings
+- `meeting:read:meeting_invitation:admin` - Read meeting invitations
+- `recording:read:admin` - Read recording information
+- `user:read:admin` - Read user information
+- `webinar:read:admin` - Read webinar information
+- `webinar:write:admin` - Manage webinars
+- `report:read:admin` - Read meeting reports and participants
+
+## Available Tools
+
+### 1. zoom_list_meetings
+
+List all scheduled meetings for the authenticated user.
+
+**Parameters:**
+- `type` (optional, enum: "scheduled" | "live" | "upcoming", default: "upcoming"): Meeting type filter
+- `page_size` (optional, integer, default: 30): Number of meetings to return (max 300)
+
+**Example:**
+```json
+{
+  "type": "upcoming",
+  "page_size": 50
+}
+```
+
+**Response:**
+```json
+{
+  "meetings": [
+    {
+      "id": "12345678",
+      "topic": "Team Standup",
+      "type": 2,
+      "start_time": "2024-01-15T10:00:00Z",
+      "duration": 30,
+      "timezone": "America/New_York",
+      "join_url": "https://zoom.us/j/12345678",
+      "agenda": "Daily standup meeting"
+    }
+  ],
+  "count": 1,
+  "total_records": 1
+}
+```
+
+### 2. zoom_get_meeting
+
+Get details of a specific meeting by ID.
+
+**Parameters:**
+- `meeting_id` (required, string): The meeting ID or UUID
+
+**Example:**
+```json
+{
+  "meeting_id": "12345678"
+}
+```
+
+**Response:**
+```json
+{
+  "id": "12345678",
+  "uuid": "abc-123-def-456",
+  "host_id": "host123",
+  "topic": "Team Standup",
+  "type": 2,
+  "status": "waiting",
+  "start_time": "2024-01-15T10:00:00Z",
+  "duration": 30,
+  "timezone": "America/New_York",
+  "agenda": "Daily standup meeting",
+  "created_at": "2024-01-10T12:00:00Z",
+  "join_url": "https://zoom.us/j/12345678",
+  "password": "abc123",
+  "settings": { ... }
+}
+```
+
+### 3. zoom_create_meeting
+
+Create a new scheduled meeting.
+
+**Parameters:**
+- `topic` (required, string): Meeting topic/title
+- `type` (optional, integer, default: 2): Meeting type
+  - 1 = Instant meeting
+  - 2 = Scheduled meeting
+  - 3 = Recurring meeting with no fixed time
+  - 8 = Recurring meeting with fixed time
+- `start_time` (optional, string): Meeting start time in ISO 8601 format
+- `duration` (optional, integer, default: 60): Meeting duration in minutes
+- `timezone` (optional, string, default: "UTC"): Timezone (e.g., "America/New_York")
+- `agenda` (optional, string): Meeting agenda/description
+
+**Example:**
+```json
+{
+  "topic": "Project Kickoff Meeting",
+  "type": 2,
+  "start_time": "2024-01-20T14:00:00",
+  "duration": 90,
+  "timezone": "America/New_York",
+  "agenda": "Discuss project goals and timeline"
+}
+```
+
+**Response:**
+```json
+{
+  "id": "87654321",
+  "uuid": "new-uuid-123",
+  "host_id": "host123",
+  "topic": "Project Kickoff Meeting",
+  "type": 2,
+  "start_time": "2024-01-20T14:00:00Z",
+  "duration": 90,
+  "timezone": "America/New_York",
+  "join_url": "https://zoom.us/j/87654321",
+  "password": "xyz789",
+  "created_at": "2024-01-15T10:00:00Z"
+}
+```
+
+### 4. zoom_update_meeting
+
+Update an existing meeting.
+
+**Parameters:**
+- `meeting_id` (required, string): The meeting ID to update
+- `topic` (optional, string): Updated meeting topic
+- `start_time` (optional, string): Updated start time in ISO 8601 format
+- `duration` (optional, integer): Updated duration in minutes
+- `agenda` (optional, string): Updated meeting agenda
+
+**Example:**
+```json
+{
+  "meeting_id": "12345678",
+  "topic": "Updated Meeting Title",
+  "duration": 45
+}
+```
+
+**Response:**
+```json
+{
+  "status": "success",
+  "message": "Meeting 12345678 updated successfully"
+}
+```
+
+### 5. zoom_delete_meeting
+
+Delete a scheduled meeting.
+
+**Parameters:**
+- `meeting_id` (required, string): The meeting ID to delete
+
+**Example:**
+```json
+{
+  "meeting_id": "12345678"
+}
+```
+
+**Response:**
+```json
+{
+  "status": "success",
+  "message": "Meeting 12345678 deleted successfully"
+}
+```
+
+### 6. zoom_get_user
+
+Get user profile information.
+
+**Parameters:**
+- `user_id` (optional, string, default: "me"): User ID or email address (use "me" for authenticated user)
+
+**Example:**
+```json
+{
+  "user_id": "me"
+}
+```
+
+**Response:**
+```json
+{
+  "id": "user123",
+  "first_name": "John",
+  "last_name": "Doe",
+  "email": "john.doe@example.com",
+  "type": 2,
+  "pmi": 1234567890,
+  "timezone": "America/New_York",
+  "verified": 1,
+  "created_at": "2020-01-01T00:00:00Z",
+  "last_login_time": "2024-01-15T08:00:00Z",
+  "pic_url": "https://example.com/pic.jpg",
+  "account_id": "account123"
+}
+```
+
+### 7. zoom_list_recordings
+
+List cloud recordings for the authenticated user.
+
+**Parameters:**
+- `from_date` (optional, string): Start date in YYYY-MM-DD format (default: 30 days ago)
+- `to_date` (optional, string): End date in YYYY-MM-DD format (default: today)
+- `page_size` (optional, integer, default: 30): Number of recordings to return (max 300)
+
+**Example:**
+```json
+{
+  "from_date": "2024-01-01",
+  "to_date": "2024-01-31",
+  "page_size": 50
+}
+```
+
+**Response:**
+```json
+{
+  "recordings": [
+    {
+      "meeting_id": "rec123",
+      "uuid": "rec-uuid-123",
+      "topic": "Recorded Meeting",
+      "start_time": "2024-01-10T10:00:00Z",
+      "duration": 60,
+      "total_size": 1024000,
+      "recording_count": 2,
+      "recording_files": [
+        {
+          "id": "file1",
+          "file_type": "MP4",
+          "file_size": 512000,
+          "download_url": "https://zoom.us/rec/download/file1",
+          "play_url": "https://zoom.us/rec/play/file1"
+        }
+      ]
+    }
+  ],
+  "count": 1,
+  "from": "2024-01-01",
+  "to": "2024-01-31"
+}
+```
+
+### 8. zoom_get_meeting_recordings
+
+Get all recordings for a specific meeting.
+
+**Parameters:**
+- `meeting_id` (required, string): The meeting ID or UUID
+
+**Example:**
+```json
+{
+  "meeting_id": "meeting123"
+}
+```
+
+**Response:**
+```json
+{
+  "uuid": "meeting-uuid",
+  "id": "meeting123",
+  "account_id": "account123",
+  "host_id": "host123",
+  "topic": "Test Meeting",
+  "start_time": "2024-01-10T10:00:00Z",
+  "duration": 60,
+  "total_size": 2048000,
+  "recording_count": 3,
+  "recording_files": [
+    {
+      "id": "file1",
+      "meeting_id": "meeting123",
+      "recording_start": "2024-01-10T10:00:00Z",
+      "recording_end": "2024-01-10T11:00:00Z",
+      "file_type": "MP4",
+      "file_size": 1024000,
+      "download_url": "https://zoom.us/rec/download/file1",
+      "play_url": "https://zoom.us/rec/play/file1",
+      "status": "completed"
+    }
+  ]
+}
+```
+
+### 9. zoom_list_webinars
+
+List all webinars for the authenticated user.
+
+**Parameters:**
+- `page_size` (optional, integer, default: 30): Number of webinars to return (max 300)
+
+**Example:**
+```json
+{
+  "page_size": 50
+}
+```
+
+**Response:**
+```json
+{
+  "webinars": [
+    {
+      "id": "web123",
+      "uuid": "web-uuid-123",
+      "topic": "Product Launch Webinar",
+      "type": 5,
+      "start_time": "2024-01-20T15:00:00Z",
+      "duration": 120,
+      "timezone": "UTC",
+      "join_url": "https://zoom.us/w/web123",
+      "agenda": "Product launch presentation"
+    }
+  ],
+  "count": 1,
+  "total_records": 1
+}
+```
+
+### 10. zoom_get_webinar
+
+Get details of a specific webinar by ID.
+
+**Parameters:**
+- `webinar_id` (required, string): The webinar ID
+
+**Example:**
+```json
+{
+  "webinar_id": "web123"
+}
+```
+
+**Response:**
+```json
+{
+  "id": "web123",
+  "uuid": "web-uuid-123",
+  "host_id": "host123",
+  "topic": "Product Launch Webinar",
+  "type": 5,
+  "start_time": "2024-01-20T15:00:00Z",
+  "duration": 120,
+  "timezone": "UTC",
+  "agenda": "Product launch presentation",
+  "created_at": "2024-01-15T10:00:00Z",
+  "join_url": "https://zoom.us/w/web123",
+  "settings": { ... }
+}
+```
+
+### 11. zoom_list_meeting_participants
+
+Get participants for a past meeting instance.
+
+**Parameters:**
+- `meeting_id` (required, string): The meeting ID or UUID
+- `page_size` (optional, integer, default: 30): Number of participants to return (max 300)
+
+**Example:**
+```json
+{
+  "meeting_id": "meeting123",
+  "page_size": 100
+}
+```
+
+**Response:**
+```json
+{
+  "participants": [
+    {
+      "id": "part1",
+      "user_id": "user123",
+      "name": "John Doe",
+      "user_email": "john@example.com",
+      "join_time": "2024-01-10T10:00:00Z",
+      "leave_time": "2024-01-10T11:00:00Z",
+      "duration": 60,
+      "status": "in_meeting"
+    }
+  ],
+  "count": 1,
+  "total_records": 1
+}
+```
+
+### 12. zoom_get_meeting_invitation
+
+Get the meeting invitation text/HTML.
+
+**Parameters:**
+- `meeting_id` (required, string): The meeting ID
+
+**Example:**
+```json
+{
+  "meeting_id": "12345678"
+}
+```
+
+**Response:**
+```json
+{
+  "invitation": "You are invited to join:\nTeam Standup\nTime: Jan 15, 2024 10:00 AM\nJoin URL: https://zoom.us/j/12345678"
+}
+```
+
+## Common Use Cases
+
+### 1. List Upcoming Meetings
+
+```json
+{
+  "tool": "zoom_list_meetings",
+  "arguments": {
+    "type": "upcoming",
+    "page_size": 50
+  }
+}
+```
+
+### 2. Create a New Meeting
+
+```json
+{
+  "tool": "zoom_create_meeting",
+  "arguments": {
+    "topic": "Weekly Team Sync",
+    "type": 2,
+    "start_time": "2024-01-22T15:00:00",
+    "duration": 60,
+    "timezone": "America/New_York",
+    "agenda": "Discuss weekly progress and blockers"
+  }
+}
+```
+
+### 3. Get Meeting Details
+
+```json
+{
+  "tool": "zoom_get_meeting",
+  "arguments": {
+    "meeting_id": "12345678"
+  }
+}
+```
+
+### 4. List Recent Recordings
+
+```json
+{
+  "tool": "zoom_list_recordings",
+  "arguments": {
+    "from_date": "2024-01-01",
+    "to_date": "2024-01-15"
+  }
+}
+```
+
+### 5. Get User Profile
+
+```json
+{
+  "tool": "zoom_get_user",
+  "arguments": {
+    "user_id": "me"
+  }
+}
+```
+
+### 6. Update Meeting Time
+
+```json
+{
+  "tool": "zoom_update_meeting",
+  "arguments": {
+    "meeting_id": "12345678",
+    "start_time": "2024-01-22T16:00:00",
+    "duration": 45
+  }
+}
+```
+
+## Error Handling
+
+The connector handles various error scenarios:
+
+### Invalid OAuth Credentials
+
+**Error:**
+```json
+{
+  "error": "Invalid or expired OAuth credentials"
+}
+```
+
+**Solution:** Re-authenticate with Zoom through the OAuth flow.
+
+### HTTP Errors
+
+**Error:**
+```json
+{
+  "error": "HTTP error: 404",
+  "message": "Meeting not found"
+}
+```
+
+**Common HTTP Status Codes:**
+- `400`: Bad request - Invalid parameters
+- `401`: Unauthorized - Invalid or expired token
+- `403`: Forbidden - Insufficient permissions
+- `404`: Not found - Meeting/resource doesn't exist
+- `429`: Rate limit exceeded
+
+**Solution:** Check the error message and ensure:
+1. The meeting ID is correct
+2. You have the required permissions (scopes)
+3. The OAuth token is valid
+4. You're not exceeding rate limits
+
+### Meeting Not Found
+
+**Error:**
+```json
+{
+  "error": "HTTP error: 404",
+  "message": "Meeting not found"
+}
+```
+
+**Solution:** Verify the meeting ID is correct and the meeting hasn't been deleted.
+
+### Insufficient Permissions
+
+**Error:**
+```json
+{
+  "error": "HTTP error: 403",
+  "message": "Insufficient permissions"
+}
+```
+
+**Solution:** Ensure your OAuth app has the required scopes enabled in the Zoom Marketplace.
+
+## Limitations
+
+1. **Rate Limits**: Zoom API has rate limits:
+   - Light: 30 requests per second
+   - Medium: 10 requests per second
+   - Heavy: 5 requests per second
+
+2. **Account Types**: Some features require specific Zoom account types:
+   - Webinars require a Webinar plan
+   - Cloud recordings require a Pro account or higher
+
+3. **Meeting Types**: The connector supports:
+   - Instant meetings (type 1)
+   - Scheduled meetings (type 2)
+   - Recurring meetings (types 3, 8)
+   - Webinars (types 5, 6, 9)
+
+4. **Participant Reports**: Only available for past meetings, not live or upcoming meetings.
+
+5. **Recording Access**: Only cloud recordings are accessible via API. Local recordings are not available.
+
+## Tips and Best Practices
+
+### 1. Use Meeting IDs Consistently
+
+Zoom uses both numeric Meeting IDs and UUIDs. Most endpoints accept both, but UUIDs are more reliable for specific meeting instances.
+
+### 2. Handle Timezones Properly
+
+Always specify timezones when creating meetings to avoid confusion:
+
+```json
+{
+  "topic": "Meeting",
+  "start_time": "2024-01-20T14:00:00",
+  "timezone": "America/New_York"
+}
+```
+
+### 3. Check Recording Availability
+
+Recordings may not be immediately available after a meeting ends. Check the `status` field.
+
+### 4. Use Pagination for Large Results
+
+For large datasets, use pagination with `page_size`:
+
+```json
+{
+  "tool": "zoom_list_meetings",
+  "arguments": {
+    "type": "upcoming",
+    "page_size": 300
+  }
+}
+```
+
+### 5. Handle Rate Limits Gracefully
+
+Implement exponential backoff when encountering 429 errors.
+
+### 6. Validate Meeting Times
+
+Ensure meeting start times are in the future when creating scheduled meetings.
+
+## Troubleshooting
+
+### Can't Create Meetings
+
+**Problem:** `zoom_create_meeting` fails with permission error.
+
+**Solution:**
+1. Verify `meeting:write:admin` scope is enabled
+2. Ensure the account has permission to schedule meetings
+3. Check that start_time is in the future for scheduled meetings
+
+### Can't Access Recordings
+
+**Problem:** `zoom_list_recordings` returns empty or error.
+
+**Solution:**
+1. Verify `recording:read:admin` scope is enabled
+2. Ensure cloud recording is enabled in Zoom account settings
+3. Check the date range - recordings may have expired
+
+### Participant List is Empty
+
+**Problem:** `zoom_list_meeting_participants` returns empty.
+
+**Solution:**
+1. Ensure the meeting has already occurred (past meeting)
+2. Verify `report:read:admin` scope is enabled
+3. Check that participant tracking is enabled for the meeting
+
+### Invalid Timezone Error
+
+**Problem:** Meeting creation fails with timezone error.
+
+**Solution:**
+Use valid timezone identifiers from the [IANA timezone database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g.:
+- `America/New_York`
+- `Europe/London`
+- `Asia/Tokyo`
+- `UTC`
+
+## Additional Resources
+
+- [Zoom API Documentation](https://developers.zoom.us/docs/api/)
+- [Zoom OAuth Guide](https://developers.zoom.us/docs/integrations/oauth/)
+- [Zoom API Reference](https://developers.zoom.us/docs/api/rest/)
+- [Zoom Marketplace](https://marketplace.zoom.us/)
+- [IANA Timezone Database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+
+## Support
+
+For issues or questions:
+1. Check the error message and this documentation
+2. Verify your OAuth setup and scopes
+3. Review Zoom API documentation for additional details
+4. Check Zoom Marketplace for app status and configuration

--- a/src/sage_mcp/config.py
+++ b/src/sage_mcp/config.py
@@ -81,6 +81,22 @@ class Settings(BaseSettings):
         env="GOOGLE_DOCS_SCOPES"
     )
 
+    # OAuth Configuration - Notion
+    notion_client_id: Optional[str] = Field(
+        default=None, env="NOTION_CLIENT_ID"
+    )
+    notion_client_secret: Optional[str] = Field(
+        default=None, env="NOTION_CLIENT_SECRET"
+    )
+
+    # OAuth Configuration - Zoom
+    zoom_client_id: Optional[str] = Field(
+        default=None, env="ZOOM_CLIENT_ID"
+    )
+    zoom_client_secret: Optional[str] = Field(
+        default=None, env="ZOOM_CLIENT_SECRET"
+    )
+
     # OAuth Configuration - Jira
     jira_client_id: Optional[str] = Field(
         default=None, env="JIRA_CLIENT_ID"

--- a/src/sage_mcp/connectors/__init__.py
+++ b/src/sage_mcp/connectors/__init__.py
@@ -7,7 +7,9 @@ from .registry import ConnectorRegistry
 from . import github  # noqa: F401
 from . import google_docs  # noqa: F401
 from . import jira  # noqa: F401
+from . import notion  # noqa: F401
 from . import slack  # noqa: F401
+from . import zoom  # noqa: F401
 # TODO: Add other connectors as they are implemented
 # from . import gitlab
 # from . import discord

--- a/src/sage_mcp/connectors/notion.py
+++ b/src/sage_mcp/connectors/notion.py
@@ -1,0 +1,872 @@
+"""Notion connector implementation for accessing Notion API."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+from mcp import types
+
+from ..models.connector import Connector, ConnectorType
+from ..models.oauth_credential import OAuthCredential
+from .base import BaseConnector
+from .registry import register_connector
+
+
+@register_connector(ConnectorType.NOTION)
+class NotionConnector(BaseConnector):
+    """Notion connector for accessing Notion databases, pages, and blocks."""
+
+    NOTION_API_BASE = "https://api.notion.com/v1"
+    NOTION_VERSION = "2022-06-28"
+
+    @property
+    def display_name(self) -> str:
+        """Return display name for the connector."""
+        return "Notion"
+
+    @property
+    def description(self) -> str:
+        """Return description of the connector."""
+        return "Access and manage Notion databases, pages, and blocks"
+
+    @property
+    def requires_oauth(self) -> bool:
+        """Return whether this connector requires OAuth."""
+        return True
+
+    async def _make_authenticated_request(
+        self,
+        method: str,
+        url: str,
+        oauth_cred: OAuthCredential,
+        **kwargs
+    ) -> httpx.Response:
+        """Make an authenticated request to Notion API.
+
+        Args:
+            method: HTTP method (GET, POST, PATCH, DELETE)
+            url: Full URL to request
+            oauth_cred: OAuth credential with access token
+            **kwargs: Additional arguments to pass to httpx request
+
+        Returns:
+            httpx.Response object
+
+        Raises:
+            httpx.HTTPStatusError: If request fails
+        """
+        headers = kwargs.get("headers", {})
+        headers["Authorization"] = f"Bearer {oauth_cred.access_token}"
+        headers["Notion-Version"] = self.NOTION_VERSION
+        headers["Content-Type"] = "application/json"
+        kwargs["headers"] = headers
+
+        async with httpx.AsyncClient() as client:
+            response = await client.request(method, url, **kwargs)
+            response.raise_for_status()
+            return response
+
+    async def get_tools(
+        self,
+        connector: Connector,
+        oauth_cred: Optional[OAuthCredential] = None
+    ) -> List[types.Tool]:
+        """Get available Notion tools.
+
+        Args:
+            connector: The connector configuration
+            oauth_cred: OAuth credential (optional)
+
+        Returns:
+            List of available tools
+        """
+        tools = [
+            types.Tool(
+                name="notion_list_databases",
+                description="List all Notion databases accessible to the integration",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_size": {
+                            "type": "integer",
+                            "description": "Number of databases to return (max 100)",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": 20
+                        }
+                    }
+                }
+            ),
+            types.Tool(
+                name="notion_search",
+                description="Search for pages and databases by title",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Search query to match against page/database titles"
+                        },
+                        "filter": {
+                            "type": "string",
+                            "description": "Filter results by type: 'page' or 'database'",
+                            "enum": ["page", "database"]
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "description": "Number of results to return (max 100)",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": 20
+                        }
+                    },
+                    "required": ["query"]
+                }
+            ),
+            types.Tool(
+                name="notion_get_page",
+                description="Get a Notion page by ID",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_id": {
+                            "type": "string",
+                            "description": "The ID of the page to retrieve"
+                        }
+                    },
+                    "required": ["page_id"]
+                }
+            ),
+            types.Tool(
+                name="notion_get_page_content",
+                description="Get the content blocks of a Notion page",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_id": {
+                            "type": "string",
+                            "description": "The ID of the page to retrieve content from"
+                        },
+                        "format": {
+                            "type": "string",
+                            "description": "Format of the output: 'plain_text' or 'structured'",
+                            "enum": ["plain_text", "structured"],
+                            "default": "plain_text"
+                        }
+                    },
+                    "required": ["page_id"]
+                }
+            ),
+            types.Tool(
+                name="notion_get_database",
+                description="Get a Notion database by ID",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "database_id": {
+                            "type": "string",
+                            "description": "The ID of the database to retrieve"
+                        }
+                    },
+                    "required": ["database_id"]
+                }
+            ),
+            types.Tool(
+                name="notion_query_database",
+                description="Query a Notion database to retrieve pages/entries",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "database_id": {
+                            "type": "string",
+                            "description": "The ID of the database to query"
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "description": "Number of results to return (max 100)",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": 20
+                        }
+                    },
+                    "required": ["database_id"]
+                }
+            ),
+            types.Tool(
+                name="notion_create_page",
+                description="Create a new page in a Notion database or as a child of another page",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "parent_id": {
+                            "type": "string",
+                            "description": "The ID of the parent database or page"
+                        },
+                        "parent_type": {
+                            "type": "string",
+                            "description": "Type of parent: 'database_id' or 'page_id'",
+                            "enum": ["database_id", "page_id"],
+                            "default": "database_id"
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Title of the new page"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Optional plain text content to add to the page"
+                        }
+                    },
+                    "required": ["parent_id", "title"]
+                }
+            ),
+            types.Tool(
+                name="notion_append_block_children",
+                description="Append blocks (content) to a page",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_id": {
+                            "type": "string",
+                            "description": "The ID of the page to append content to"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Plain text content to append to the page"
+                        }
+                    },
+                    "required": ["page_id", "content"]
+                }
+            ),
+            types.Tool(
+                name="notion_update_page",
+                description="Update a page's properties (title, metadata)",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_id": {
+                            "type": "string",
+                            "description": "The ID of the page to update"
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "New title for the page"
+                        }
+                    },
+                    "required": ["page_id", "title"]
+                }
+            ),
+            types.Tool(
+                name="notion_get_block",
+                description="Get a specific block by ID",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "block_id": {
+                            "type": "string",
+                            "description": "The ID of the block to retrieve"
+                        }
+                    },
+                    "required": ["block_id"]
+                }
+            )
+        ]
+        return tools
+
+    async def get_resources(
+        self,
+        connector: Connector,
+        oauth_cred: Optional[OAuthCredential] = None
+    ) -> List[types.Resource]:
+        """Get available Notion resources.
+
+        Args:
+            connector: The connector configuration
+            oauth_cred: OAuth credential (optional)
+
+        Returns:
+            List of available resources
+        """
+        if not oauth_cred or not self.validate_oauth_credential(oauth_cred):
+            return []
+
+        try:
+            # Search for all pages and databases
+            response = await self._make_authenticated_request(
+                "POST",
+                f"{self.NOTION_API_BASE}/search",
+                oauth_cred,
+                json={"page_size": 50}
+            )
+            results = response.json().get("results", [])
+
+            resources = []
+            for item in results:
+                item_type = item.get("object")
+                item_id = item.get("id")
+
+                # Get title based on type
+                title = "Untitled"
+                if item_type == "page":
+                    properties = item.get("properties", {})
+                    title_prop = properties.get("title", {})
+                    if isinstance(title_prop, dict) and "title" in title_prop:
+                        title_array = title_prop["title"]
+                        if title_array and len(title_array) > 0:
+                            title = title_array[0].get("plain_text", "Untitled")
+                elif item_type == "database":
+                    title_array = item.get("title", [])
+                    if title_array and len(title_array) > 0:
+                        title = title_array[0].get("plain_text", "Untitled")
+
+                resources.append(types.Resource(
+                    uri=f"notion://{item_type}/{item_id}",
+                    name=title,
+                    description=f"Notion {item_type.capitalize()}",
+                    mimeType=f"application/vnd.notion.{item_type}"
+                ))
+
+            return resources
+        except Exception:
+            return []
+
+    async def execute_tool(
+        self,
+        connector: Connector,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        oauth_cred: Optional[OAuthCredential] = None
+    ) -> str:
+        """Execute a Notion tool.
+
+        Args:
+            connector: The connector configuration
+            tool_name: Name of the tool to execute
+            arguments: Tool arguments
+            oauth_cred: OAuth credential (optional)
+
+        Returns:
+            JSON string result
+        """
+        if not oauth_cred or not self.validate_oauth_credential(oauth_cred):
+            return json.dumps({"error": "Invalid or expired OAuth credentials"})
+
+        try:
+            if tool_name == "list_databases":
+                return await self._list_databases(arguments, oauth_cred)
+            elif tool_name == "search":
+                return await self._search(arguments, oauth_cred)
+            elif tool_name == "get_page":
+                return await self._get_page(arguments, oauth_cred)
+            elif tool_name == "get_page_content":
+                return await self._get_page_content(arguments, oauth_cred)
+            elif tool_name == "get_database":
+                return await self._get_database(arguments, oauth_cred)
+            elif tool_name == "query_database":
+                return await self._query_database(arguments, oauth_cred)
+            elif tool_name == "create_page":
+                return await self._create_page(arguments, oauth_cred)
+            elif tool_name == "append_block_children":
+                return await self._append_block_children(arguments, oauth_cred)
+            elif tool_name == "update_page":
+                return await self._update_page(arguments, oauth_cred)
+            elif tool_name == "get_block":
+                return await self._get_block(arguments, oauth_cred)
+            else:
+                return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+        except httpx.HTTPStatusError as e:
+            return json.dumps({
+                "error": f"HTTP error: {e.response.status_code}",
+                "message": e.response.text
+            })
+        except Exception as e:
+            return json.dumps({"error": f"Error executing tool '{tool_name}': {str(e)}"})
+
+    async def read_resource(
+        self,
+        connector: Connector,
+        resource_path: str,
+        oauth_cred: Optional[OAuthCredential] = None
+    ) -> str:
+        """Read a Notion resource.
+
+        Args:
+            connector: The connector configuration
+            resource_path: Resource path (format: {type}/{id})
+            oauth_cred: OAuth credential (optional)
+
+        Returns:
+            Resource content as string
+        """
+        if not oauth_cred or not self.validate_oauth_credential(oauth_cred):
+            return "Error: Invalid or expired OAuth credentials"
+
+        try:
+            parts = resource_path.split("/", 1)
+            if len(parts) != 2:
+                return "Error: Invalid resource path format. Expected: {type}/{id}"
+
+            resource_type, resource_id = parts
+
+            if resource_type == "page":
+                # Get page content
+                response = await self._make_authenticated_request(
+                    "GET",
+                    f"{self.NOTION_API_BASE}/pages/{resource_id}",
+                    oauth_cred
+                )
+                page_data = response.json()
+
+                # Get page blocks
+                blocks_response = await self._make_authenticated_request(
+                    "GET",
+                    f"{self.NOTION_API_BASE}/blocks/{resource_id}/children",
+                    oauth_cred
+                )
+                blocks_data = blocks_response.json()
+
+                # Extract title
+                title = self._extract_page_title(page_data)
+
+                # Extract content
+                content = self._extract_plain_text_from_blocks(blocks_data.get("results", []))
+
+                return f"Page: {title}\n\n{content}"
+
+            elif resource_type == "database":
+                # Get database info
+                response = await self._make_authenticated_request(
+                    "GET",
+                    f"{self.NOTION_API_BASE}/databases/{resource_id}",
+                    oauth_cred
+                )
+                db_data = response.json()
+
+                # Extract database title
+                title_array = db_data.get("title", [])
+                title = title_array[0].get("plain_text", "Untitled") if title_array else "Untitled"
+
+                # Get database schema
+                properties = db_data.get("properties", {})
+                schema_info = "\n".join([
+                    f"  - {name}: {prop.get('type')}"
+                    for name, prop in properties.items()
+                ])
+
+                return f"Database: {title}\n\nProperties:\n{schema_info}"
+
+            else:
+                return f"Error: Unknown resource type: {resource_type}"
+
+        except httpx.HTTPStatusError as e:
+            return f"Error: HTTP {e.response.status_code} - {e.response.text}"
+        except Exception as e:
+            return f"Error reading resource: {str(e)}"
+
+    # Tool implementation methods
+
+    async def _list_databases(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """List all Notion databases."""
+        page_size = arguments.get("page_size", 20)
+
+        response = await self._make_authenticated_request(
+            "POST",
+            f"{self.NOTION_API_BASE}/search",
+            oauth_cred,
+            json={
+                "filter": {"property": "object", "value": "database"},
+                "page_size": page_size
+            }
+        )
+
+        data = response.json()
+        results = data.get("results", [])
+
+        databases = []
+        for db in results:
+            title_array = db.get("title", [])
+            title = title_array[0].get("plain_text", "Untitled") if title_array else "Untitled"
+
+            databases.append({
+                "id": db.get("id"),
+                "title": title,
+                "created_time": db.get("created_time"),
+                "last_edited_time": db.get("last_edited_time"),
+                "url": db.get("url")
+            })
+
+        return json.dumps({
+            "databases": databases,
+            "count": len(databases),
+            "has_more": data.get("has_more", False)
+        }, indent=2)
+
+    async def _search(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Search for pages and databases."""
+        query = arguments.get("query", "")
+        filter_type = arguments.get("filter")
+        page_size = arguments.get("page_size", 20)
+
+        search_params: Dict[str, Any] = {
+            "query": query,
+            "page_size": page_size
+        }
+
+        if filter_type:
+            search_params["filter"] = {"property": "object", "value": filter_type}
+
+        response = await self._make_authenticated_request(
+            "POST",
+            f"{self.NOTION_API_BASE}/search",
+            oauth_cred,
+            json=search_params
+        )
+
+        data = response.json()
+        results = data.get("results", [])
+
+        items = []
+        for item in results:
+            item_type = item.get("object")
+
+            # Extract title based on type
+            if item_type == "page":
+                title = self._extract_page_title(item)
+            elif item_type == "database":
+                title_array = item.get("title", [])
+                title = title_array[0].get("plain_text", "Untitled") if title_array else "Untitled"
+            else:
+                title = "Untitled"
+
+            items.append({
+                "id": item.get("id"),
+                "type": item_type,
+                "title": title,
+                "created_time": item.get("created_time"),
+                "last_edited_time": item.get("last_edited_time"),
+                "url": item.get("url")
+            })
+
+        return json.dumps({
+            "results": items,
+            "count": len(items),
+            "has_more": data.get("has_more", False)
+        }, indent=2)
+
+    async def _get_page(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get a Notion page by ID."""
+        page_id = arguments["page_id"]
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.NOTION_API_BASE}/pages/{page_id}",
+            oauth_cred
+        )
+
+        page_data = response.json()
+
+        return json.dumps({
+            "id": page_data.get("id"),
+            "created_time": page_data.get("created_time"),
+            "last_edited_time": page_data.get("last_edited_time"),
+            "archived": page_data.get("archived"),
+            "url": page_data.get("url"),
+            "properties": page_data.get("properties", {})
+        }, indent=2)
+
+    async def _get_page_content(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get the content blocks of a Notion page."""
+        page_id = arguments["page_id"]
+        format_type = arguments.get("format", "plain_text")
+
+        # Get page metadata
+        page_response = await self._make_authenticated_request(
+            "GET",
+            f"{self.NOTION_API_BASE}/pages/{page_id}",
+            oauth_cred
+        )
+        page_data = page_response.json()
+        title = self._extract_page_title(page_data)
+
+        # Get page blocks
+        blocks_response = await self._make_authenticated_request(
+            "GET",
+            f"{self.NOTION_API_BASE}/blocks/{page_id}/children",
+            oauth_cred
+        )
+        blocks_data = blocks_response.json()
+
+        if format_type == "plain_text":
+            content = self._extract_plain_text_from_blocks(blocks_data.get("results", []))
+            return f"Title: {title}\n\n{content}"
+        else:
+            return json.dumps({
+                "title": title,
+                "page_id": page_id,
+                "blocks": blocks_data.get("results", [])
+            }, indent=2)
+
+    async def _get_database(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get a Notion database by ID."""
+        database_id = arguments["database_id"]
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.NOTION_API_BASE}/databases/{database_id}",
+            oauth_cred
+        )
+
+        db_data = response.json()
+
+        title_array = db_data.get("title", [])
+        title = title_array[0].get("plain_text", "Untitled") if title_array else "Untitled"
+
+        return json.dumps({
+            "id": db_data.get("id"),
+            "title": title,
+            "created_time": db_data.get("created_time"),
+            "last_edited_time": db_data.get("last_edited_time"),
+            "url": db_data.get("url"),
+            "properties": db_data.get("properties", {})
+        }, indent=2)
+
+    async def _query_database(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Query a Notion database."""
+        database_id = arguments["database_id"]
+        page_size = arguments.get("page_size", 20)
+
+        response = await self._make_authenticated_request(
+            "POST",
+            f"{self.NOTION_API_BASE}/databases/{database_id}/query",
+            oauth_cred,
+            json={"page_size": page_size}
+        )
+
+        data = response.json()
+        results = data.get("results", [])
+
+        pages = []
+        for page in results:
+            title = self._extract_page_title(page)
+
+            pages.append({
+                "id": page.get("id"),
+                "title": title,
+                "created_time": page.get("created_time"),
+                "last_edited_time": page.get("last_edited_time"),
+                "url": page.get("url"),
+                "properties": page.get("properties", {})
+            })
+
+        return json.dumps({
+            "pages": pages,
+            "count": len(pages),
+            "has_more": data.get("has_more", False)
+        }, indent=2)
+
+    async def _create_page(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Create a new page in Notion."""
+        parent_id = arguments["parent_id"]
+        parent_type = arguments.get("parent_type", "database_id")
+        title = arguments["title"]
+        content = arguments.get("content")
+
+        # Build parent object
+        parent = {parent_type: parent_id}
+
+        # Build properties
+        properties = {
+            "title": {
+                "title": [{"text": {"content": title}}]
+            }
+        }
+
+        # Build children blocks if content is provided
+        children = []
+        if content:
+            children.append({
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [{"type": "text", "text": {"content": content}}]
+                }
+            })
+
+        page_data: Dict[str, Any] = {
+            "parent": parent,
+            "properties": properties
+        }
+
+        if children:
+            page_data["children"] = children
+
+        response = await self._make_authenticated_request(
+            "POST",
+            f"{self.NOTION_API_BASE}/pages",
+            oauth_cred,
+            json=page_data
+        )
+
+        result = response.json()
+
+        return json.dumps({
+            "id": result.get("id"),
+            "url": result.get("url"),
+            "created_time": result.get("created_time")
+        }, indent=2)
+
+    async def _append_block_children(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Append blocks to a page."""
+        page_id = arguments["page_id"]
+        content = arguments["content"]
+
+        # Create paragraph block
+        children = [{
+            "object": "block",
+            "type": "paragraph",
+            "paragraph": {
+                "rich_text": [{"type": "text", "text": {"content": content}}]
+            }
+        }]
+
+        response = await self._make_authenticated_request(
+            "PATCH",
+            f"{self.NOTION_API_BASE}/blocks/{page_id}/children",
+            oauth_cred,
+            json={"children": children}
+        )
+
+        result = response.json()
+
+        return json.dumps({
+            "status": "success",
+            "blocks_added": len(result.get("results", []))
+        }, indent=2)
+
+    async def _update_page(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Update a page's properties."""
+        page_id = arguments["page_id"]
+        title = arguments["title"]
+
+        properties = {
+            "title": {
+                "title": [{"text": {"content": title}}]
+            }
+        }
+
+        response = await self._make_authenticated_request(
+            "PATCH",
+            f"{self.NOTION_API_BASE}/pages/{page_id}",
+            oauth_cred,
+            json={"properties": properties}
+        )
+
+        result = response.json()
+
+        return json.dumps({
+            "id": result.get("id"),
+            "url": result.get("url"),
+            "last_edited_time": result.get("last_edited_time")
+        }, indent=2)
+
+    async def _get_block(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get a specific block by ID."""
+        block_id = arguments["block_id"]
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.NOTION_API_BASE}/blocks/{block_id}",
+            oauth_cred
+        )
+
+        block_data = response.json()
+
+        return json.dumps(block_data, indent=2)
+
+    # Helper methods
+
+    def _extract_page_title(self, page_data: Dict[str, Any]) -> str:
+        """Extract title from page properties."""
+        properties = page_data.get("properties", {})
+
+        # Look for title property
+        for prop_name, prop_value in properties.items():
+            if prop_value.get("type") == "title":
+                title_array = prop_value.get("title", [])
+                if title_array and len(title_array) > 0:
+                    return title_array[0].get("plain_text", "Untitled")
+
+        return "Untitled"
+
+    def _extract_plain_text_from_blocks(self, blocks: List[Dict[str, Any]]) -> str:
+        """Extract plain text from Notion blocks."""
+        text_parts = []
+
+        for block in blocks:
+            block_type = block.get("type")
+
+            if block_type in ["paragraph", "heading_1", "heading_2", "heading_3",
+                              "bulleted_list_item", "numbered_list_item", "to_do", "quote"]:
+                block_content = block.get(block_type, {})
+                rich_text = block_content.get("rich_text", [])
+
+                for text_element in rich_text:
+                    if text_element.get("type") == "text":
+                        text_parts.append(text_element.get("plain_text", ""))
+
+                text_parts.append("\n")
+
+            elif block_type == "code":
+                code_content = block.get("code", {})
+                rich_text = code_content.get("rich_text", [])
+
+                code_text = "".join([
+                    text_element.get("plain_text", "")
+                    for text_element in rich_text
+                    if text_element.get("type") == "text"
+                ])
+
+                text_parts.append(f"```\n{code_text}\n```\n")
+
+        return "".join(text_parts)

--- a/src/sage_mcp/connectors/zoom.py
+++ b/src/sage_mcp/connectors/zoom.py
@@ -1,0 +1,890 @@
+"""Zoom connector implementation for accessing Zoom API."""
+
+import json
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timedelta
+
+import httpx
+from mcp import types
+
+from ..models.connector import Connector, ConnectorType
+from ..models.oauth_credential import OAuthCredential
+from .base import BaseConnector
+from .registry import register_connector
+
+
+@register_connector(ConnectorType.ZOOM)
+class ZoomConnector(BaseConnector):
+    """Zoom connector for accessing meetings, webinars, and recordings."""
+
+    ZOOM_API_BASE = "https://api.zoom.us/v2"
+
+    @property
+    def display_name(self) -> str:
+        """Return display name for the connector."""
+        return "Zoom"
+
+    @property
+    def description(self) -> str:
+        """Return description of the connector."""
+        return "Access and manage Zoom meetings, webinars, users, and recordings"
+
+    @property
+    def requires_oauth(self) -> bool:
+        """Return whether this connector requires OAuth."""
+        return True
+
+    async def _make_authenticated_request(
+        self,
+        method: str,
+        url: str,
+        oauth_cred: OAuthCredential,
+        **kwargs
+    ) -> httpx.Response:
+        """Make an authenticated request to Zoom API.
+
+        Args:
+            method: HTTP method (GET, POST, PATCH, DELETE)
+            url: Full URL to request
+            oauth_cred: OAuth credential with access token
+            **kwargs: Additional arguments to pass to httpx request
+
+        Returns:
+            httpx.Response object
+
+        Raises:
+            httpx.HTTPStatusError: If request fails
+        """
+        headers = kwargs.get("headers", {})
+        headers["Authorization"] = f"Bearer {oauth_cred.access_token}"
+        headers["Content-Type"] = "application/json"
+        kwargs["headers"] = headers
+
+        async with httpx.AsyncClient() as client:
+            response = await client.request(method, url, **kwargs)
+            response.raise_for_status()
+            return response
+
+    async def get_tools(
+        self,
+        connector: Connector,
+        oauth_cred: Optional[OAuthCredential] = None
+    ) -> List[types.Tool]:
+        """Get available Zoom tools.
+
+        Args:
+            connector: The connector configuration
+            oauth_cred: OAuth credential (optional)
+
+        Returns:
+            List of available tools
+        """
+        tools = [
+            types.Tool(
+                name="zoom_list_meetings",
+                description="List all scheduled meetings for the authenticated user",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Meeting type filter",
+                            "enum": ["scheduled", "live", "upcoming"],
+                            "default": "upcoming"
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "description": "Number of meetings to return (max 300)",
+                            "minimum": 1,
+                            "maximum": 300,
+                            "default": 30
+                        }
+                    }
+                }
+            ),
+            types.Tool(
+                name="zoom_get_meeting",
+                description="Get details of a specific meeting by ID",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "meeting_id": {
+                            "type": "string",
+                            "description": "The meeting ID or UUID"
+                        }
+                    },
+                    "required": ["meeting_id"]
+                }
+            ),
+            types.Tool(
+                name="zoom_create_meeting",
+                description="Create a new scheduled meeting",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "Meeting topic/title"
+                        },
+                        "type": {
+                            "type": "integer",
+                            "description": "Meeting type: 1=Instant, 2=Scheduled, 3=Recurring with no fixed time, 8=Recurring with fixed time",
+                            "enum": [1, 2, 3, 8],
+                            "default": 2
+                        },
+                        "start_time": {
+                            "type": "string",
+                            "description": "Meeting start time in ISO 8601 format (YYYY-MM-DDTHH:mm:ss)"
+                        },
+                        "duration": {
+                            "type": "integer",
+                            "description": "Meeting duration in minutes",
+                            "default": 60
+                        },
+                        "timezone": {
+                            "type": "string",
+                            "description": "Timezone (e.g., America/New_York)",
+                            "default": "UTC"
+                        },
+                        "agenda": {
+                            "type": "string",
+                            "description": "Meeting agenda/description"
+                        }
+                    },
+                    "required": ["topic"]
+                }
+            ),
+            types.Tool(
+                name="zoom_update_meeting",
+                description="Update an existing meeting",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "meeting_id": {
+                            "type": "string",
+                            "description": "The meeting ID to update"
+                        },
+                        "topic": {
+                            "type": "string",
+                            "description": "Updated meeting topic/title"
+                        },
+                        "start_time": {
+                            "type": "string",
+                            "description": "Updated start time in ISO 8601 format"
+                        },
+                        "duration": {
+                            "type": "integer",
+                            "description": "Updated duration in minutes"
+                        },
+                        "agenda": {
+                            "type": "string",
+                            "description": "Updated meeting agenda"
+                        }
+                    },
+                    "required": ["meeting_id"]
+                }
+            ),
+            types.Tool(
+                name="zoom_delete_meeting",
+                description="Delete a scheduled meeting",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "meeting_id": {
+                            "type": "string",
+                            "description": "The meeting ID to delete"
+                        }
+                    },
+                    "required": ["meeting_id"]
+                }
+            ),
+            types.Tool(
+                name="zoom_get_user",
+                description="Get user profile information",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "user_id": {
+                            "type": "string",
+                            "description": "User ID or email address (use 'me' for authenticated user)",
+                            "default": "me"
+                        }
+                    }
+                }
+            ),
+            types.Tool(
+                name="zoom_list_recordings",
+                description="List cloud recordings for the authenticated user",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "from_date": {
+                            "type": "string",
+                            "description": "Start date in YYYY-MM-DD format (default: 30 days ago)"
+                        },
+                        "to_date": {
+                            "type": "string",
+                            "description": "End date in YYYY-MM-DD format (default: today)"
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "description": "Number of recordings to return (max 300)",
+                            "minimum": 1,
+                            "maximum": 300,
+                            "default": 30
+                        }
+                    }
+                }
+            ),
+            types.Tool(
+                name="zoom_get_meeting_recordings",
+                description="Get all recordings for a specific meeting",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "meeting_id": {
+                            "type": "string",
+                            "description": "The meeting ID or UUID"
+                        }
+                    },
+                    "required": ["meeting_id"]
+                }
+            ),
+            types.Tool(
+                name="zoom_list_webinars",
+                description="List all webinars for the authenticated user",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_size": {
+                            "type": "integer",
+                            "description": "Number of webinars to return (max 300)",
+                            "minimum": 1,
+                            "maximum": 300,
+                            "default": 30
+                        }
+                    }
+                }
+            ),
+            types.Tool(
+                name="zoom_get_webinar",
+                description="Get details of a specific webinar by ID",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "webinar_id": {
+                            "type": "string",
+                            "description": "The webinar ID"
+                        }
+                    },
+                    "required": ["webinar_id"]
+                }
+            ),
+            types.Tool(
+                name="zoom_list_meeting_participants",
+                description="Get participants for a past meeting instance",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "meeting_id": {
+                            "type": "string",
+                            "description": "The meeting ID or UUID"
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "description": "Number of participants to return (max 300)",
+                            "minimum": 1,
+                            "maximum": 300,
+                            "default": 30
+                        }
+                    },
+                    "required": ["meeting_id"]
+                }
+            ),
+            types.Tool(
+                name="zoom_get_meeting_invitation",
+                description="Get the meeting invitation text/HTML",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "meeting_id": {
+                            "type": "string",
+                            "description": "The meeting ID"
+                        }
+                    },
+                    "required": ["meeting_id"]
+                }
+            )
+        ]
+        return tools
+
+    async def get_resources(
+        self,
+        connector: Connector,
+        oauth_cred: Optional[OAuthCredential] = None
+    ) -> List[types.Resource]:
+        """Get available Zoom resources.
+
+        Args:
+            connector: The connector configuration
+            oauth_cred: OAuth credential (optional)
+
+        Returns:
+            List of available resources
+        """
+        if not oauth_cred or not self.validate_oauth_credential(oauth_cred):
+            return []
+
+        try:
+            # List upcoming meetings
+            response = await self._make_authenticated_request(
+                "GET",
+                f"{self.ZOOM_API_BASE}/users/me/meetings",
+                oauth_cred,
+                params={"type": "upcoming", "page_size": 50}
+            )
+            meetings = response.json().get("meetings", [])
+
+            resources = []
+            for meeting in meetings:
+                resources.append(types.Resource(
+                    uri=f"zoom://meeting/{meeting['id']}",
+                    name=meeting.get("topic", "Untitled Meeting"),
+                    description=f"Zoom Meeting - {meeting.get('start_time', 'No start time')}",
+                    mimeType="application/vnd.zoom.meeting"
+                ))
+
+            return resources
+        except Exception:
+            return []
+
+    async def execute_tool(
+        self,
+        connector: Connector,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        oauth_cred: Optional[OAuthCredential] = None
+    ) -> str:
+        """Execute a Zoom tool.
+
+        Args:
+            connector: The connector configuration
+            tool_name: Name of the tool to execute
+            arguments: Tool arguments
+            oauth_cred: OAuth credential (optional)
+
+        Returns:
+            JSON string result
+        """
+        if not oauth_cred or not self.validate_oauth_credential(oauth_cred):
+            return json.dumps({"error": "Invalid or expired OAuth credentials"})
+
+        try:
+            if tool_name == "list_meetings":
+                return await self._list_meetings(arguments, oauth_cred)
+            elif tool_name == "get_meeting":
+                return await self._get_meeting(arguments, oauth_cred)
+            elif tool_name == "create_meeting":
+                return await self._create_meeting(arguments, oauth_cred)
+            elif tool_name == "update_meeting":
+                return await self._update_meeting(arguments, oauth_cred)
+            elif tool_name == "delete_meeting":
+                return await self._delete_meeting(arguments, oauth_cred)
+            elif tool_name == "get_user":
+                return await self._get_user(arguments, oauth_cred)
+            elif tool_name == "list_recordings":
+                return await self._list_recordings(arguments, oauth_cred)
+            elif tool_name == "get_meeting_recordings":
+                return await self._get_meeting_recordings(arguments, oauth_cred)
+            elif tool_name == "list_webinars":
+                return await self._list_webinars(arguments, oauth_cred)
+            elif tool_name == "get_webinar":
+                return await self._get_webinar(arguments, oauth_cred)
+            elif tool_name == "list_meeting_participants":
+                return await self._list_meeting_participants(arguments, oauth_cred)
+            elif tool_name == "get_meeting_invitation":
+                return await self._get_meeting_invitation(arguments, oauth_cred)
+            else:
+                return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+        except httpx.HTTPStatusError as e:
+            return json.dumps({
+                "error": f"HTTP error: {e.response.status_code}",
+                "message": e.response.text
+            })
+        except Exception as e:
+            return json.dumps({"error": f"Error executing tool '{tool_name}': {str(e)}"})
+
+    async def read_resource(
+        self,
+        connector: Connector,
+        resource_path: str,
+        oauth_cred: Optional[OAuthCredential] = None
+    ) -> str:
+        """Read a Zoom resource.
+
+        Args:
+            connector: The connector configuration
+            resource_path: Resource path (format: {type}/{id})
+            oauth_cred: OAuth credential (optional)
+
+        Returns:
+            Resource content as string
+        """
+        if not oauth_cred or not self.validate_oauth_credential(oauth_cred):
+            return "Error: Invalid or expired OAuth credentials"
+
+        try:
+            parts = resource_path.split("/", 1)
+            if len(parts) != 2:
+                return "Error: Invalid resource path format. Expected: {type}/{id}"
+
+            resource_type, resource_id = parts
+
+            if resource_type == "meeting":
+                response = await self._make_authenticated_request(
+                    "GET",
+                    f"{self.ZOOM_API_BASE}/meetings/{resource_id}",
+                    oauth_cred
+                )
+                meeting_data = response.json()
+
+                return f"""Meeting: {meeting_data.get('topic', 'Untitled')}
+ID: {meeting_data.get('id')}
+Start Time: {meeting_data.get('start_time', 'Not scheduled')}
+Duration: {meeting_data.get('duration', 'N/A')} minutes
+Join URL: {meeting_data.get('join_url', 'N/A')}
+Agenda: {meeting_data.get('agenda', 'No agenda')}
+"""
+            else:
+                return f"Error: Unknown resource type: {resource_type}"
+
+        except httpx.HTTPStatusError as e:
+            return f"Error: HTTP {e.response.status_code} - {e.response.text}"
+        except Exception as e:
+            return f"Error reading resource: {str(e)}"
+
+    # Tool implementation methods
+
+    async def _list_meetings(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """List meetings for the authenticated user."""
+        meeting_type = arguments.get("type", "upcoming")
+        page_size = arguments.get("page_size", 30)
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/users/me/meetings",
+            oauth_cred,
+            params={"type": meeting_type, "page_size": page_size}
+        )
+
+        data = response.json()
+        meetings = data.get("meetings", [])
+
+        result = []
+        for meeting in meetings:
+            result.append({
+                "id": meeting.get("id"),
+                "topic": meeting.get("topic"),
+                "type": meeting.get("type"),
+                "start_time": meeting.get("start_time"),
+                "duration": meeting.get("duration"),
+                "timezone": meeting.get("timezone"),
+                "join_url": meeting.get("join_url"),
+                "agenda": meeting.get("agenda")
+            })
+
+        return json.dumps({
+            "meetings": result,
+            "count": len(result),
+            "total_records": data.get("total_records", len(result))
+        }, indent=2)
+
+    async def _get_meeting(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get a specific meeting by ID."""
+        meeting_id = arguments["meeting_id"]
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/meetings/{meeting_id}",
+            oauth_cred
+        )
+
+        meeting_data = response.json()
+
+        return json.dumps({
+            "id": meeting_data.get("id"),
+            "uuid": meeting_data.get("uuid"),
+            "host_id": meeting_data.get("host_id"),
+            "topic": meeting_data.get("topic"),
+            "type": meeting_data.get("type"),
+            "status": meeting_data.get("status"),
+            "start_time": meeting_data.get("start_time"),
+            "duration": meeting_data.get("duration"),
+            "timezone": meeting_data.get("timezone"),
+            "agenda": meeting_data.get("agenda"),
+            "created_at": meeting_data.get("created_at"),
+            "join_url": meeting_data.get("join_url"),
+            "password": meeting_data.get("password"),
+            "settings": meeting_data.get("settings", {})
+        }, indent=2)
+
+    async def _create_meeting(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Create a new meeting."""
+        meeting_data: Dict[str, Any] = {
+            "topic": arguments["topic"],
+            "type": arguments.get("type", 2),
+            "duration": arguments.get("duration", 60),
+            "timezone": arguments.get("timezone", "UTC")
+        }
+
+        if "start_time" in arguments:
+            meeting_data["start_time"] = arguments["start_time"]
+
+        if "agenda" in arguments:
+            meeting_data["agenda"] = arguments["agenda"]
+
+        response = await self._make_authenticated_request(
+            "POST",
+            f"{self.ZOOM_API_BASE}/users/me/meetings",
+            oauth_cred,
+            json=meeting_data
+        )
+
+        result = response.json()
+
+        return json.dumps({
+            "id": result.get("id"),
+            "uuid": result.get("uuid"),
+            "host_id": result.get("host_id"),
+            "topic": result.get("topic"),
+            "type": result.get("type"),
+            "start_time": result.get("start_time"),
+            "duration": result.get("duration"),
+            "timezone": result.get("timezone"),
+            "join_url": result.get("join_url"),
+            "password": result.get("password"),
+            "created_at": result.get("created_at")
+        }, indent=2)
+
+    async def _update_meeting(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Update an existing meeting."""
+        meeting_id = arguments["meeting_id"]
+
+        update_data: Dict[str, Any] = {}
+        if "topic" in arguments:
+            update_data["topic"] = arguments["topic"]
+        if "start_time" in arguments:
+            update_data["start_time"] = arguments["start_time"]
+        if "duration" in arguments:
+            update_data["duration"] = arguments["duration"]
+        if "agenda" in arguments:
+            update_data["agenda"] = arguments["agenda"]
+
+        await self._make_authenticated_request(
+            "PATCH",
+            f"{self.ZOOM_API_BASE}/meetings/{meeting_id}",
+            oauth_cred,
+            json=update_data
+        )
+
+        return json.dumps({
+            "status": "success",
+            "message": f"Meeting {meeting_id} updated successfully"
+        }, indent=2)
+
+    async def _delete_meeting(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Delete a meeting."""
+        meeting_id = arguments["meeting_id"]
+
+        await self._make_authenticated_request(
+            "DELETE",
+            f"{self.ZOOM_API_BASE}/meetings/{meeting_id}",
+            oauth_cred
+        )
+
+        return json.dumps({
+            "status": "success",
+            "message": f"Meeting {meeting_id} deleted successfully"
+        }, indent=2)
+
+    async def _get_user(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get user information."""
+        user_id = arguments.get("user_id", "me")
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/users/{user_id}",
+            oauth_cred
+        )
+
+        user_data = response.json()
+
+        return json.dumps({
+            "id": user_data.get("id"),
+            "first_name": user_data.get("first_name"),
+            "last_name": user_data.get("last_name"),
+            "email": user_data.get("email"),
+            "type": user_data.get("type"),
+            "pmi": user_data.get("pmi"),
+            "timezone": user_data.get("timezone"),
+            "verified": user_data.get("verified"),
+            "created_at": user_data.get("created_at"),
+            "last_login_time": user_data.get("last_login_time"),
+            "pic_url": user_data.get("pic_url"),
+            "account_id": user_data.get("account_id")
+        }, indent=2)
+
+    async def _list_recordings(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """List cloud recordings."""
+        # Default to last 30 days if not specified
+        to_date = arguments.get("to_date", datetime.now().strftime("%Y-%m-%d"))
+        from_date = arguments.get(
+            "from_date",
+            (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
+        )
+        page_size = arguments.get("page_size", 30)
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/users/me/recordings",
+            oauth_cred,
+            params={
+                "from": from_date,
+                "to": to_date,
+                "page_size": page_size
+            }
+        )
+
+        data = response.json()
+        meetings = data.get("meetings", [])
+
+        result = []
+        for meeting in meetings:
+            recording_files = meeting.get("recording_files", [])
+            result.append({
+                "meeting_id": meeting.get("id"),
+                "uuid": meeting.get("uuid"),
+                "topic": meeting.get("topic"),
+                "start_time": meeting.get("start_time"),
+                "duration": meeting.get("duration"),
+                "total_size": meeting.get("total_size"),
+                "recording_count": meeting.get("recording_count"),
+                "recording_files": [
+                    {
+                        "id": f.get("id"),
+                        "file_type": f.get("file_type"),
+                        "file_size": f.get("file_size"),
+                        "download_url": f.get("download_url"),
+                        "play_url": f.get("play_url")
+                    }
+                    for f in recording_files
+                ]
+            })
+
+        return json.dumps({
+            "recordings": result,
+            "count": len(result),
+            "from": from_date,
+            "to": to_date
+        }, indent=2)
+
+    async def _get_meeting_recordings(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get recordings for a specific meeting."""
+        meeting_id = arguments["meeting_id"]
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/meetings/{meeting_id}/recordings",
+            oauth_cred
+        )
+
+        data = response.json()
+
+        recording_files = data.get("recording_files", [])
+        result = {
+            "uuid": data.get("uuid"),
+            "id": data.get("id"),
+            "account_id": data.get("account_id"),
+            "host_id": data.get("host_id"),
+            "topic": data.get("topic"),
+            "start_time": data.get("start_time"),
+            "duration": data.get("duration"),
+            "total_size": data.get("total_size"),
+            "recording_count": data.get("recording_count"),
+            "recording_files": [
+                {
+                    "id": f.get("id"),
+                    "meeting_id": f.get("meeting_id"),
+                    "recording_start": f.get("recording_start"),
+                    "recording_end": f.get("recording_end"),
+                    "file_type": f.get("file_type"),
+                    "file_size": f.get("file_size"),
+                    "download_url": f.get("download_url"),
+                    "play_url": f.get("play_url"),
+                    "status": f.get("status")
+                }
+                for f in recording_files
+            ]
+        }
+
+        return json.dumps(result, indent=2)
+
+    async def _list_webinars(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """List webinars for the authenticated user."""
+        page_size = arguments.get("page_size", 30)
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/users/me/webinars",
+            oauth_cred,
+            params={"page_size": page_size}
+        )
+
+        data = response.json()
+        webinars = data.get("webinars", [])
+
+        result = []
+        for webinar in webinars:
+            result.append({
+                "id": webinar.get("id"),
+                "uuid": webinar.get("uuid"),
+                "topic": webinar.get("topic"),
+                "type": webinar.get("type"),
+                "start_time": webinar.get("start_time"),
+                "duration": webinar.get("duration"),
+                "timezone": webinar.get("timezone"),
+                "join_url": webinar.get("join_url"),
+                "agenda": webinar.get("agenda")
+            })
+
+        return json.dumps({
+            "webinars": result,
+            "count": len(result),
+            "total_records": data.get("total_records", len(result))
+        }, indent=2)
+
+    async def _get_webinar(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get a specific webinar by ID."""
+        webinar_id = arguments["webinar_id"]
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/webinars/{webinar_id}",
+            oauth_cred
+        )
+
+        webinar_data = response.json()
+
+        return json.dumps({
+            "id": webinar_data.get("id"),
+            "uuid": webinar_data.get("uuid"),
+            "host_id": webinar_data.get("host_id"),
+            "topic": webinar_data.get("topic"),
+            "type": webinar_data.get("type"),
+            "start_time": webinar_data.get("start_time"),
+            "duration": webinar_data.get("duration"),
+            "timezone": webinar_data.get("timezone"),
+            "agenda": webinar_data.get("agenda"),
+            "created_at": webinar_data.get("created_at"),
+            "join_url": webinar_data.get("join_url"),
+            "settings": webinar_data.get("settings", {})
+        }, indent=2)
+
+    async def _list_meeting_participants(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """List participants for a past meeting."""
+        meeting_id = arguments["meeting_id"]
+        page_size = arguments.get("page_size", 30)
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/past_meetings/{meeting_id}/participants",
+            oauth_cred,
+            params={"page_size": page_size}
+        )
+
+        data = response.json()
+        participants = data.get("participants", [])
+
+        result = []
+        for participant in participants:
+            result.append({
+                "id": participant.get("id"),
+                "user_id": participant.get("user_id"),
+                "name": participant.get("name"),
+                "user_email": participant.get("user_email"),
+                "join_time": participant.get("join_time"),
+                "leave_time": participant.get("leave_time"),
+                "duration": participant.get("duration"),
+                "status": participant.get("status")
+            })
+
+        return json.dumps({
+            "participants": result,
+            "count": len(result),
+            "total_records": data.get("total_records", len(result))
+        }, indent=2)
+
+    async def _get_meeting_invitation(
+        self,
+        arguments: Dict[str, Any],
+        oauth_cred: OAuthCredential
+    ) -> str:
+        """Get meeting invitation text."""
+        meeting_id = arguments["meeting_id"]
+
+        response = await self._make_authenticated_request(
+            "GET",
+            f"{self.ZOOM_API_BASE}/meetings/{meeting_id}/invitation",
+            oauth_cred
+        )
+
+        data = response.json()
+
+        return json.dumps({
+            "invitation": data.get("invitation", "")
+        }, indent=2)

--- a/src/sage_mcp/models/connector.py
+++ b/src/sage_mcp/models/connector.py
@@ -48,6 +48,7 @@ class ConnectorType(enum.Enum):
     SLACK = "slack"
     TEAMS = "teams"
     DISCORD = "discord"
+    ZOOM = "zoom"
 
 
 class Connector(Base):


### PR DESCRIPTION
Add Notion (10 tools) and Zoom (12 tools) MCP connectors with OAuth support and comprehensive tests (37 passing). Create detailed architecture documentation with 10+ Mermaid diagrams. Update README with visual architecture diagram and connector logos for better documentation.