### PR TITLE
fix created_at and updated_at fields for persistence

### DIFF
--- a/frontend/src/pages/Tenants.tsx
+++ b/frontend/src/pages/Tenants.tsx
@@ -234,10 +234,12 @@ const TenantCard = ({ tenant }: { tenant: Tenant }) => {
                     <span>{tenant.contact_email}</span>
                   </div>
                 )}
-                <div className="flex items-center space-x-1">
-                  <Calendar className="h-3 w-3" />
-                  <span>Created {new Date(tenant.created_at || '').toLocaleDateString()}</span>
-                </div>
+                {tenant.created_at && (
+                  <div className="flex items-center space-x-1">
+                    <Calendar className="h-3 w-3" />
+                    <span>Created {new Date(tenant.created_at).toLocaleDateString()}</span>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/sage_mcp/api/admin.py
+++ b/src/sage_mcp/api/admin.py
@@ -1,5 +1,6 @@
 """Admin API routes for tenant and connector management."""
 
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -28,6 +29,8 @@ class TenantResponse(BaseModel):
     description: Optional[str]
     is_active: bool
     contact_email: Optional[str]
+    created_at: datetime
+    updated_at: datetime
 
     class Config:
         from_attributes = True
@@ -47,6 +50,9 @@ class ConnectorResponse(BaseModel):
     description: Optional[str]
     is_enabled: bool
     configuration: Optional[Dict[str, Any]]
+    tenant_id: UUID
+    created_at: datetime
+    updated_at: datetime
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
Fix invalid created date issue in tenants display page

After Fix:

<img width="531" height="194" alt="Screenshot 2025-11-03 at 10 31 32 AM" src="https://github.com/user-attachments/assets/e725bc62-8d28-44de-948c-3f4381f785e1" />
