### PR TITLE
Add community standards files to meet GitHub OSS requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Description
+
+<!-- Provide a clear and concise description of your changes -->
+
+## Type of Change
+
+<!-- Mark the relevant option with an 'x' -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Related Issues
+
+<!-- Link to related issues using #issue_number -->
+
+Fixes #
+
+## Testing
+
+<!-- Describe the tests you ran and how to reproduce them -->
+
+- [ ] All existing tests pass
+- [ ] Added new tests for changes (if applicable)
+- [ ] Tested locally
+
+## Checklist
+
+- [ ] My code follows the project's code style
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code where necessary
+- [ ] I have updated the documentation accordingly
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots to help explain your changes -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Being respectful of differing opinions and experiences
+* Giving and gracefully accepting constructive feedback
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and unwelcome sexual attention
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers. All complaints will be reviewed and investigated promptly and fairly.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to SageMCP
+
+Thank you for your interest in contributing to SageMCP! This document provides guidelines for contributing to the project.
+
+## How to Contribute
+
+### Reporting Bugs
+
+- Use the bug report template when creating an issue
+- Include clear reproduction steps and environment details
+- Provide relevant logs or error messages
+
+### Suggesting Features
+
+- Use the feature request template
+- Clearly describe the problem and proposed solution
+- Explain why this feature would be useful to the community
+
+### Pull Requests
+
+1. Fork the repository and create a branch from `main`
+2. Make your changes following the existing code style
+3. Write or update tests as needed
+4. Ensure all tests pass
+5. Update documentation if necessary
+6. Submit a pull request with a clear description of changes
+
+### Development Setup
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/SageMCP.git
+cd SageMCP
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Run tests
+pytest
+```
+
+## Code Style
+
+- Follow PEP 8 guidelines for Python code
+- Use meaningful variable and function names
+- Add comments for complex logic
+- Keep functions focused and concise
+
+## Commit Messages
+
+- Use clear, descriptive commit messages
+- Reference related issues when applicable
+- Sign your commits if repository rules require it
+
+## License
+
+By contributing to SageMCP, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities in the following versions:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in SageMCP, please report it by emailing the maintainers directly rather than opening a public issue.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+When reporting a vulnerability, please include:
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Suggested fix (if any)
+
+We will acknowledge your email within 48 hours and send a more detailed response within 7 days indicating the next steps in handling your report.
+
+After the initial reply to your report, we will keep you informed of the progress towards a fix and may ask for additional information.
+
+## Disclosure Policy
+
+When we receive a security bug report, we will:
+
+1. Confirm the problem and determine affected versions
+2. Audit code to find similar problems
+3. Prepare fixes for all supported releases
+4. Release patches as soon as possible
+
+Thank you for helping keep SageMCP and its users safe!


### PR DESCRIPTION
  - Add CODE_OF_CONDUCT.md based on Contributor Covenant 2.0
  - Add CONTRIBUTING.md with guidelines for bug reports, features, and PRs
  - Add pull request template with structured checklist
  - Add SECURITY.md with vulnerability reporting policy